### PR TITLE
Select Contrast color by theme

### DIFF
--- a/monarch-qc-dashboard/src/components/SimpleDashboard.vue
+++ b/monarch-qc-dashboard/src/components/SimpleDashboard.vue
@@ -20,7 +20,7 @@
         <tr
           v-for="([key, value], index) of getVisualDiffs(a, b)"
           :key="key"
-          :style="index % 2 === 0 ? 'background-color: #f2f2f2;' : 'background-color: transparent;'"
+          :style="getRowStyle(index)"
         >
           <td>{{ key }}</td>
           <td align="center">{{ value }}</td>
@@ -38,6 +38,7 @@
 
 <script setup lang="ts">
   import { getVisualDiffs } from "./SimpleDashboard"
+  import { getRowStyle } from "../style"
   defineProps<{
     title: string
     label: string

--- a/monarch-qc-dashboard/src/style.css
+++ b/monarch-qc-dashboard/src/style.css
@@ -13,6 +13,8 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+  --dark-mode-contrast-background-color: #333333;
+  --light-mode-contrast-background-color: #f2f2f2;
 }
 
 a {

--- a/monarch-qc-dashboard/src/style.ts
+++ b/monarch-qc-dashboard/src/style.ts
@@ -1,0 +1,15 @@
+// Detect if the browser is using dark mode
+export function isDarkMode(): boolean {
+  return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+}
+
+// Return the appropriate row style based on the color scheme
+export function getRowStyle(index: number) {
+  const contrastBackgroundColor = isDarkMode()
+    ? "var(--dark-mode-contrast-background-color)"
+    : "var(--light-mode-contrast-background-color)"
+
+  return {
+    backgroundColor: index % 2 === 0 ? contrastBackgroundColor : "transparent",
+  }
+}


### PR DESCRIPTION
This creates new contrast colors by theme and uses them in SimpleDashboard. We should try to reuse these for further contrast later. Fixes #49 