### PR TITLE
Add Node Report to single page QC

### DIFF
--- a/monarch-qc-dashboard/src/App.vue
+++ b/monarch-qc-dashboard/src/App.vue
@@ -52,6 +52,13 @@
         </li>
       </ul>
     </div>
+    <SimpleDashboard
+      title="Nodes Report"
+      label="Ingest"
+      a_name="Nodes"
+      b_name="Other Nodes"
+      :data="edgesDashboardData"
+    />
   </main>
 </template>
 
@@ -69,6 +76,7 @@
     edgesDashboardData,
     edgesTimeSeriesData,
     globalNamespaces,
+    nodesDashboardData,
   } from "./data"
   import SimpleDashboard from "./components/SimpleDashboard.vue"
   import SelectReport from "./components/SelectReport.vue"

--- a/monarch-qc-dashboard/src/App.vue
+++ b/monarch-qc-dashboard/src/App.vue
@@ -5,6 +5,13 @@
   <main>
     <div>
       <img src="/src/global/monarch.png" class="logo" alt="Monarch Logo" />
+      <SelectReport
+        id="selectDataSet"
+        label=""
+        :reportNames="dataNames"
+        v-model="selectedData"
+        :onChange="updateData"
+      />
     </div>
     <SelectReport
       id="selectCompareReport"
@@ -52,6 +59,9 @@
   import { computed } from "vue"
   import {
     globalReports,
+    dataNames,
+    selectedData,
+    updateData,
     selectedReport,
     compareNames,
     selectedCompare,

--- a/monarch-qc-dashboard/src/App.vue
+++ b/monarch-qc-dashboard/src/App.vue
@@ -31,8 +31,7 @@
     <SimpleDashboard
       title="Edges Report"
       label="Ingest"
-      a_name="Edges"
-      b_name="Dangling Edges"
+      :colorCols="['edges']"
       :data="edgesDashboardData"
     />
     <LineChart
@@ -55,8 +54,7 @@
     <SimpleDashboard
       title="Nodes Report"
       label="Ingest"
-      a_name="Nodes"
-      b_name="Other Nodes"
+      :colorCols="['Nodes']"
       :data="edgesDashboardData"
     />
   </main>

--- a/monarch-qc-dashboard/src/App.vue
+++ b/monarch-qc-dashboard/src/App.vue
@@ -28,6 +28,7 @@
       v-model="selectedReport"
       :onChange="processReports"
     />
+    <h2>Edges Report</h2>
     <SimpleDashboard
       title="Edges Report"
       label="Ingest"
@@ -51,12 +52,25 @@
         </li>
       </ul>
     </div>
-    <SimpleDashboard
-      title="Nodes Report"
-      label="Ingest"
-      :colorCols="['Nodes']"
-      :data="edgesDashboardData"
-    />
+    <div>
+      <h2>Nodes Report</h2>
+      <div style="display: inline-block; margin-right: 20px; vertical-align: top">
+        <SimpleDashboard
+          title="Nodes Report"
+          label="Category"
+          :colorCols="['node_stats']"
+          :data="nodesDashboardData_category"
+        />
+      </div>
+      <div style="display: inline-block; margin-right: 20px; vertical-align: top">
+        <SimpleDashboard
+          title="Nodes Report"
+          label="ID"
+          :colorCols="['node_stats']"
+          :data="nodesDashboardData_id"
+        />
+      </div>
+    </div>
   </main>
 </template>
 
@@ -74,7 +88,8 @@
     edgesDashboardData,
     edgesTimeSeriesData,
     globalNamespaces,
-    nodesDashboardData,
+    nodesDashboardData_category,
+    nodesDashboardData_id,
   } from "./data"
   import SimpleDashboard from "./components/SimpleDashboard.vue"
   import SelectReport from "./components/SelectReport.vue"

--- a/monarch-qc-dashboard/src/components/SimpleDashboard.vue
+++ b/monarch-qc-dashboard/src/components/SimpleDashboard.vue
@@ -5,7 +5,6 @@
   algorithm.
  -->
 <template>
-  <h2>{{ title }}</h2>
   <div align="center">
     <table>
       <thead>

--- a/monarch-qc-dashboard/src/components/SimpleDashboard.vue
+++ b/monarch-qc-dashboard/src/components/SimpleDashboard.vue
@@ -11,43 +11,48 @@
       <thead>
         <tr>
           <th>{{ label }}</th>
-          <th style="padding-right: 10px">{{ a_name }}</th>
-          <th style="padding-right: 10px">{{ a_name }} (⚫) vs {{ b_name }} (⚪)</th>
-          <th>{{ b_name }}</th>
+          <template v-for="field in fields" :key="field">
+            <th style="padding-right: 10px">{{ titleFormat(field) }}</th>
+            <template v-if="getNextField(field, data) !== null">
+              <th style="text-align: center">
+                {{ titleFormat(field) }} (⚫) vs {{ titleFormat(getNextField(field, data)) }} (⚪)
+              </th>
+            </template>
+          </template>
         </tr>
       </thead>
       <tbody>
-        <tr
-          v-for="([key, value], index) of getVisualDiffs(data.a, data.b)"
-          :key="key"
-          :style="getRowStyle(index)"
-        >
-          <td>{{ key }}</td>
-          <td style="padding-right: 10px">
-            {{ (data.a.get(key) ?? 0).toLocaleString("en-US") }}
-            <span
-              v-if="data.a_diff.has(key) && (data.a_diff.get(key) ?? 0) > 0"
-              style="color: green; font-style: italic"
-            >
-              (+{{ data.a_diff.get(key)?.toLocaleString("en-US") }})
-            </span>
-            <span
-              v-if="data.a_diff.has(key) && (data.a_diff.get(key) ?? 0) < 0"
-              style="color: red; font-weight: bold"
-            >
-              ({{ data.a_diff.get(key)?.toLocaleString("en-US") }})
-            </span>
-          </td>
-          <td style="text-align: center">{{ value }}</td>
-          <td style="padding-left: 10px">
-            {{ (data.b.get(key) ?? 0).toLocaleString("en-US") }}
-            <span v-if="data.b_diff.has(key) && (data.b_diff.get(key) ?? 0) > 0">
-              (+{{ data.b_diff.get(key)?.toLocaleString("en-US") }})
-            </span>
-            <span v-if="data.b_diff.has(key) && (data.b_diff.get(key) ?? 0) < 0">
-              ({{ data.b_diff.get(key)?.toLocaleString("en-US") }})
-            </span>
-          </td>
+        <tr v-for="(label, index) in labels" :key="label" :style="getRowStyle(index)">
+          <td>{{ label }}</td>
+          <template v-for="field in fields" :key="field">
+            <td style="padding-right: 10px">
+              {{ (data[field].value.get(label) ?? 0).toLocaleString("en-US") }}
+              <template v-if="colorCols.includes(field)">
+                <span
+                  v-if="data[field].diff.has(label) && (data[field].diff.get(label) ?? 0) > 0"
+                  style="color: green; font-style: italic"
+                >
+                  (+{{ data[field].diff.get(label)?.toLocaleString("en-US") }})
+                </span>
+                <span
+                  v-if="data[field].diff.has(label) && (data[field].diff.get(label) ?? 0) < 0"
+                  style="color: red; font-weight: bold"
+                >
+                  ({{ data[field].diff.get(label)?.toLocaleString("en-US") }})
+                </span>
+              </template>
+              <template v-if="!colorCols.includes(field)">
+                <span v-if="data[field].diff.has(label) && (data[field].diff.get(label) ?? 0) > 0">
+                  (+{{ data[field].diff.get(label)?.toLocaleString("en-US") }})
+                </span>
+                <span v-if="data[field].diff.has(label) && (data[field].diff.get(label) ?? 0) < 0">
+                  ({{ data[field].diff.get(label)?.toLocaleString("en-US") }})
+                </span>
+              </template>
+            </td>
+            <template v-if="getNextField(field, data) !== null"></template>
+            <td style="text-align: center">{{ visualDiffs.get(field)?.get(label) }}</td>
+          </template>
         </tr>
       </tbody>
     </table>
@@ -55,13 +60,16 @@
 </template>
 
 <script setup lang="ts">
-  import { getVisualDiffs, DashboardData } from "./SimpleDashboard"
-  import { getRowStyle } from "../style"
-  defineProps<{
+  import { DashboardData, getAllVisualDiffs, getDataLabels, getNextField } from "./SimpleDashboard"
+  import { getRowStyle, titleFormat } from "../style"
+  import { computed } from "vue"
+  const { data } = defineProps<{
     title: string
     label: string
-    a_name: string
-    b_name: string
+    colorCols: string[]
     data: DashboardData
   }>()
+  const fields = computed(() => Object.keys(data))
+  const labels = computed(() => getDataLabels(data))
+  const visualDiffs = computed(() => getAllVisualDiffs(data))
 </script>

--- a/monarch-qc-dashboard/src/data.ts
+++ b/monarch-qc-dashboard/src/data.ts
@@ -180,7 +180,7 @@ export async function processReports() {
 
   const selected: qc.QCReport = await getQCReport(selected_name)
   const previous: qc.QCReport = await getQCReport(compare_name)
-  setDashboardData(edgesDashboardData, selected, previous, "edges", "dangling_edges")
+  setDashboardData(edgesDashboardData, selected, previous, ["edges", "dangling_edges"])
 
   const timeSeriesReports = await getTimeSeriesReports(selected_name, compare_name)
   setEdgesTimeSeriesData(edgesTimeSeriesData, timeSeriesReports, "edges")
@@ -218,8 +218,7 @@ function setDashboardData(
   data: DashboardData,
   selected: qc.QCReport,
   previous: qc.QCReport,
-  name_a: string,
-  name_b: string
+  names: string[]
 ) {
   /**
    * Sets the dashboard data for the given QCReports and parts.
@@ -230,12 +229,13 @@ function setDashboardData(
    * @in_qc: string
    * @return: void
    */
-  const key_a = name_a as keyof qc.QCReport
-  const key_b = name_b as keyof qc.QCReport
-  data.a = getTotalNumber(selected[key_a], true)
-  data.b = getTotalNumber(selected[key_b], true)
-  data.a_diff = getDifference(selected[key_a], previous[key_a])
-  data.b_diff = getDifference(selected[key_b], previous[key_b])
+  for (const name of names) {
+    const field = name as keyof qc.QCReport
+    data[name] = {
+      value: getTotalNumber(selected[field], true),
+      diff: getDifference(selected[field], previous[field]),
+    }
+  }
 }
 
 function setNodeDashboardData(
@@ -256,10 +256,16 @@ function setNodeDashboardData(
    */
   const key_a = name_a as keyof qc.StatReport
   const key_b = name_b as keyof qc.StatReport
-  data.a = getNodeTotalNumber(selected[key_a], true)
-  data.b = getNodeTotalNumber(selected[key_b], true)
-  data.a_diff = getNodeDifference(selected[key_a], previous[key_a])
-  data.b_diff = getNodeDifference(selected[key_b], previous[key_b])
+
+  data[name_a] = {
+    value: getNodeTotalNumber(selected[key_a], true),
+    diff: getNodeDifference(selected[key_a], previous[key_b]),
+  }
+
+  data[name_b] = {
+    value: getNodeTotalNumber(selected[key_b], true),
+    diff: getNodeDifference(selected[key_b], previous[key_b]),
+  }
 }
 
 function getTotalNumber(qcpart: qc.QCPart[], addTotal = false): Map<string, number> {

--- a/monarch-qc-dashboard/src/data.ts
+++ b/monarch-qc-dashboard/src/data.ts
@@ -19,6 +19,8 @@ export const edgesTimeSeriesData = reactive({} as LineChartData)
 
 export const globalNamespaces = ref<Array<string>>([])
 
+export const nodesDashboardData = reactive({} as DashboardData)
+
 const qcbase = "https://data.monarchinitiative.org/"
 
 const qcdata = new Map<string, string>([
@@ -186,6 +188,10 @@ export async function processReports() {
   const danglingEdgesNamespaces: string[] = qc.getNamespaces(selected.dangling_edges)
   const edgesNamespaces: string[] = qc.getNamespaces(selected.edges)
   globalNamespaces.value = qc.stringSetDiff(danglingEdgesNamespaces, edgesNamespaces)
+
+  const selectedStats: qc.QCReport = await getQCReport(selected_name)
+  const previousStats: qc.QCReport = await getQCReport(compare_name)
+  // setDashboardData(edgesDashboardData, selectedStats, previousStats, "edges", "dangling_edges")
 }
 
 export async function getQCReport(reportName: string): Promise<qc.QCReport> {

--- a/monarch-qc-dashboard/src/main.ts
+++ b/monarch-qc-dashboard/src/main.ts
@@ -1,10 +1,10 @@
 import { createApp } from "vue"
 import "./style.css"
 import App from "./App.vue"
-import { fetchAllData } from "./data"
+import { updateData } from "./data"
 import VueApexCharts from "vue3-apexcharts"
 
-fetchAllData()
+updateData()
 
 const app = createApp(App)
 

--- a/monarch-qc-dashboard/src/qc_utils.ts
+++ b/monarch-qc-dashboard/src/qc_utils.ts
@@ -40,6 +40,32 @@ export function toQCReport(i: object = {}): QCReport {
   }
 }
 
+export interface StatCount {
+  count: number
+  provided_by: Map<string, { count: number }>
+}
+
+export interface EdgeStatPart {
+  count_by_predicates: Map<string, StatCount>
+  count_by_spo: Map<string, StatCount>
+  predicates: string[]
+  provided_by: string[]
+  total_edges: number
+}
+
+export interface NodeStatPart {
+  count_by_category: Map<string, Map<string, number>>
+  predicates: string[]
+  provided_by: string[]
+  total_nodes: number
+}
+
+export interface StatReport {
+  edge_stats: EdgeStatPart
+  graph_name: string
+  node_stats: NodeStatPart
+}
+
 export function getNamespaces(qcparts: QCPart[]): string[] {
   /**
    * Returns all namespaces in the QCPart.

--- a/monarch-qc-dashboard/src/qc_utils.ts
+++ b/monarch-qc-dashboard/src/qc_utils.ts
@@ -46,22 +46,36 @@ export function isQCReport(i: object): i is QCReport {
 
 export interface StatCount {
   count: number
-  provided_by: Map<string, { count: number }>
+  provided_by: { [key: string]: { count: number } }
 }
 
 export interface EdgeStatPart {
-  count_by_predicates: Map<string, StatCount>
-  count_by_spo: Map<string, StatCount>
+  count_by_predicates: { [key: string]: StatCount }
+  count_by_spo: { [key: string]: StatCount }
   predicates: string[]
   provided_by: string[]
   total_edges: number
 }
 
+export function isEdgeStatPart(i: object | string): i is EdgeStatPart {
+  if (typeof i === "string") return false
+  return "count_by_predicates" in i && "count_by_spo" in i
+}
+
 export interface NodeStatPart {
-  count_by_category: Map<string, Map<string, number>>
-  predicates: string[]
+  count_by_category: { [key: string]: StatCount }
+  count_by_id_prefixes: { [key: string]: number }
+  count_by_id_prefixes_by_category: { [key: string]: { [key: string]: StatCount } }
+  node_categories: string[]
+  node_id_prefixes: string[]
+  node_id_prefixes_by_category: { [key: string]: string[] }
   provided_by: string[]
   total_nodes: number
+}
+
+export function isNodeStatPart(i: object | string): i is NodeStatPart {
+  if (typeof i != "object") return false
+  return "count_by_category" in i && "count_by_id_prefixes" in i
 }
 
 export interface StatReport {

--- a/monarch-qc-dashboard/src/qc_utils.ts
+++ b/monarch-qc-dashboard/src/qc_utils.ts
@@ -40,6 +40,10 @@ export function toQCReport(i: object = {}): QCReport {
   }
 }
 
+export function isQCReport(i: object): i is QCReport {
+  return "dangling_edges" in i && "edges" in i && "missing_nodes" in i && "nodes" in i
+}
+
 export interface StatCount {
   count: number
   provided_by: Map<string, { count: number }>
@@ -64,6 +68,19 @@ export interface StatReport {
   edge_stats: EdgeStatPart
   graph_name: string
   node_stats: NodeStatPart
+}
+
+export function toStatReport(i: object = {}): StatReport {
+  const o = <StatReport>i
+  return {
+    edge_stats: o.edge_stats ?? {},
+    graph_name: o.graph_name ?? "",
+    node_stats: o.node_stats ?? {},
+  }
+}
+
+export function isStatReport(i: object): i is StatReport {
+  return "edge_stats" in i && "graph_name" in i && "node_stats" in i
 }
 
 export function getNamespaces(qcparts: QCPart[]): string[] {

--- a/monarch-qc-dashboard/src/style.ts
+++ b/monarch-qc-dashboard/src/style.ts
@@ -1,10 +1,17 @@
-// Detect if the browser is using dark mode
 export function isDarkMode(): boolean {
+  /**
+   * Returns true if the user's OS is in dark mode.
+   * @return: boolean
+   */
   return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
 }
 
-// Return the appropriate row style based on the color scheme
 export function getRowStyle(index: number) {
+  /**
+   * Returns the appropriate row style based on the color scheme.
+   * @index: number
+   * @return: string
+   */
   const contrastBackgroundColor = isDarkMode()
     ? "var(--dark-mode-contrast-background-color)"
     : "var(--light-mode-contrast-background-color)"
@@ -12,4 +19,14 @@ export function getRowStyle(index: number) {
   return {
     backgroundColor: index % 2 === 0 ? contrastBackgroundColor : "transparent",
   }
+}
+
+export function titleFormat(title: string | null) {
+  /**
+   * Returns the title with underscores replaced with spaces and the first letter capitalized.
+   * @title: string | null
+   * @return: string
+   */
+  if (title === null) return ""
+  return title.replace(/_/g, " ").replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase()))
 }

--- a/monarch-qc-dashboard/test/components/SimpleDashboard.test.ts
+++ b/monarch-qc-dashboard/test/components/SimpleDashboard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest"
-import { getAllVisualDiffs, DashboardData } from "../../src/components/SimpleDashboard"
+import {
+  DashboardData,
+  getAllVisualDiffs,
+  getDataLabels,
+} from "../../src/components/SimpleDashboard"
 
 describe("getAllVisualDiffs tests", () => {
   test("getAllVisualDiffs empty maps", () => {
@@ -142,5 +146,18 @@ describe("getAllVisualDiffs tests", () => {
         ],
       ])
     )
+  })
+})
+
+describe("getDataLabels tests", () => {
+  test("getDataLabels empty data", () => {
+    const data: DashboardData = {}
+    expect(getDataLabels(data)).toEqual([])
+  })
+  test("getDataLabels non-empty data", () => {
+    const data: DashboardData = {
+      x: { value: new Map([["a", 1]]), diff: new Map() },
+    }
+    expect(getDataLabels(data)).toEqual(["a"])
   })
 })

--- a/monarch-qc-dashboard/test/components/SimpleDashboard.test.ts
+++ b/monarch-qc-dashboard/test/components/SimpleDashboard.test.ts
@@ -1,93 +1,145 @@
 import { describe, expect, test } from "vitest"
-import { getVisualDiffs } from "../../src/components/SimpleDashboard"
+import { getAllVisualDiffs, DashboardData } from "../../src/components/SimpleDashboard"
 
-describe("getVisualDiffs tests", () => {
-  test("getVisualDiffs empty maps", () => {
-    expect(getVisualDiffs(new Map(), new Map())).toEqual(new Map())
+describe("getAllVisualDiffs tests", () => {
+  test("getAllVisualDiffs empty maps", () => {
+    expect(getAllVisualDiffs({} as DashboardData)).toEqual(new Map())
   })
-  test("getVisualDiffs empty map and non-empty map", () => {
-    expect(getVisualDiffs(new Map([["a", 1]]), new Map())).toEqual(
-      new Map([["a", "⚫⚫⚫⚫⚫⚫⚫⚫⚫⚫"]])
-    )
-  })
-  test("getVisualDiffs non-empty map and empty map", () => {
-    expect(getVisualDiffs(new Map(), new Map([["a", 1]]))).toEqual(
-      new Map([["a", "⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪"]])
-    )
-  })
-  test("getVisualDiffs equal maps", () => {
-    expect(getVisualDiffs(new Map([["a", 1]]), new Map([["a", 1]]))).toEqual(
-      new Map([["a", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"]])
-    )
-  })
-  test("getVisualDiffs equal maps out of order", () => {
+  test("getAllVisualDiffs empty map and non-empty map", () => {
     expect(
-      getVisualDiffs(
-        new Map([
-          ["a", 1],
-          ["b", 2],
-        ]),
-        new Map([
-          ["b", 2],
-          ["a", 1],
-        ])
-      )
+      getAllVisualDiffs({
+        x: { value: new Map([["a", 1]]), diff: new Map() },
+        y: { value: new Map(), diff: new Map() },
+      })
+    ).toEqual(new Map([["x", new Map([["a", "⚫⚫⚫⚫⚫⚫⚫⚫⚫⚫"]])]]))
+  })
+  test("getAllVisualDiffs non-empty map and empty map", () => {
+    expect(
+      getAllVisualDiffs({
+        x: { value: new Map(), diff: new Map() },
+        y: { value: new Map([["a", 1]]), diff: new Map() },
+      })
+    ).toEqual(new Map([["x", new Map([["a", "⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪"]])]]))
+  })
+  test("getAllVisualDiffs equal maps", () => {
+    expect(
+      getAllVisualDiffs({
+        x: { value: new Map([["a", 1]]), diff: new Map() },
+        y: { value: new Map([["a", 1]]), diff: new Map() },
+      })
+    ).toEqual(new Map([["x", new Map([["a", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"]])]]))
+  })
+  test("getAllVisualDiffs equal maps out of order", () => {
+    expect(
+      getAllVisualDiffs({
+        x: {
+          value: new Map([
+            ["a", 1],
+            ["b", 2],
+          ]),
+          diff: new Map(),
+        },
+        y: {
+          value: new Map([
+            ["b", 2],
+            ["a", 1],
+          ]),
+          diff: new Map(),
+        },
+      })
     ).toEqual(
       new Map([
-        ["a", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"],
-        ["b", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"],
+        [
+          "x",
+          new Map([
+            ["a", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"],
+            ["b", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"],
+          ]),
+        ],
       ])
     )
   })
-  test("getVisualDiffs non-equal maps", () => {
-    expect(getVisualDiffs(new Map([["a", 1]]), new Map([["b", 2]]))).toEqual(
+  test("getAllVisualDiffs non-equal maps", () => {
+    expect(
+      getAllVisualDiffs({
+        x: { value: new Map([["a", 1]]), diff: new Map() },
+        y: { value: new Map([["b", 2]]), diff: new Map() },
+      })
+    ).toEqual(
       new Map([
-        ["a", "⚫⚫⚫⚫⚫⚫⚫⚫⚫⚫"],
-        ["b", "⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪"],
+        [
+          "x",
+          new Map([
+            ["a", "⚫⚫⚫⚫⚫⚫⚫⚫⚫⚫"],
+            ["b", "⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪"],
+          ]),
+        ],
       ])
     )
   })
-  test("getVisualDiffs non-equal maps out of order", () => {
+  test("getAllVisualDiffs non-equal maps out of order", () => {
     expect(
-      getVisualDiffs(
-        new Map([
-          ["a", 1],
-          ["b", 2],
-        ]),
-        new Map([
-          ["b", 2],
-          ["c", 3],
-        ])
-      )
+      getAllVisualDiffs({
+        x: {
+          value: new Map([
+            ["a", 1],
+            ["b", 2],
+          ]),
+          diff: new Map(),
+        },
+        y: {
+          value: new Map([
+            ["b", 2],
+            ["c", 3],
+          ]),
+          diff: new Map(),
+        },
+      })
     ).toEqual(
       new Map([
-        ["a", "⚫⚫⚫⚫⚫⚫⚫⚫⚫⚫"],
-        ["b", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"],
-        ["c", "⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪"],
+        [
+          "x",
+          new Map([
+            ["a", "⚫⚫⚫⚫⚫⚫⚫⚫⚫⚫"],
+            ["b", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"],
+            ["c", "⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪"],
+          ]),
+        ],
       ])
     )
   })
-  test("getVisualDiffs non-equal maps out of order with total number", () => {
+  test("getAllVisualDiffs non-equal maps out of order with total number", () => {
     expect(
-      getVisualDiffs(
-        new Map([
-          ["a", 1],
-          ["b", 2],
-          ["Total Number", 3],
-        ]),
-        new Map([
-          ["b", 2],
-          ["c", 3],
-          ["Total Number", 5],
-        ])
-      )
+      getAllVisualDiffs({
+        x: {
+          value: new Map([
+            ["a", 1],
+            ["b", 2],
+            ["Total Number", 3],
+          ]),
+          diff: new Map(),
+        },
+        y: {
+          value: new Map([
+            ["b", 2],
+            ["c", 3],
+            ["Total Number", 5],
+          ]),
+          diff: new Map(),
+        },
+      })
     ).toEqual(
       new Map([
-        ["a", "⚫⚫⚫⚫⚫⚫⚫⚫⚫⚫"],
-        ["b", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"],
-        ["c", "⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪"],
-        ["-------------", "-------------"],
-        ["Total Number", "⚫⚫⚫⚪⚪⚪⚪⚪⚪⚪"],
+        [
+          "x",
+          new Map([
+            ["a", "⚫⚫⚫⚫⚫⚫⚫⚫⚫⚫"],
+            ["b", "⚫⚫⚫⚫⚫⚪⚪⚪⚪⚪"],
+            ["c", "⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪"],
+            ["-------------", "-------------"],
+            ["Total Number", "⚫⚫⚫⚪⚪⚪⚪⚪⚪⚪"],
+          ]),
+        ],
       ])
     )
   })

--- a/monarch-qc-dashboard/test/data.test.ts
+++ b/monarch-qc-dashboard/test/data.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 
-import { fetchAllData, fetchQCReports, globalReports } from "../src/data"
+import { updateData, fetchQCReports, globalReports } from "../src/data"
 
 function createRequestHandler(url: string) {
   const mockPath = url.replace("https://data.monarchinitiative.org/", "test/mock_http/")
@@ -36,7 +36,7 @@ server.listen({ onUnhandledRequest: "error" })
 
 describe("fetchAllData tests", async () => {
   // @vitest-environment jsdom
-  await fetchAllData()
+  await updateData()
   test("fetchAllData globalReports", async () => {
     expect(globalReports.value).toEqual(
       new Map([

--- a/monarch-qc-dashboard/test/data.test.ts
+++ b/monarch-qc-dashboard/test/data.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest"
 import { http, HttpResponse } from "msw"
 import { setupServer } from "msw/node"
 
-import { updateData, fetchQCReports, globalReports } from "../src/data"
+import { updateData, fetchQCReports, globalReports, globalStats } from "../src/data"
 
 function createRequestHandler(url: string) {
   const mockPath = url.replace("https://data.monarchinitiative.org/", "test/mock_http/")
@@ -18,21 +18,37 @@ function createHTTPGet(url: string, path: string) {
   })
 }
 
-const urls = [
+function createURLS(base: string, sub: string[], files: string[]) {
+  const urls: string[] = []
+  for (const s of sub) {
+    for (const f of files) {
+      urls.push(base + s + "/" + f)
+    }
+  }
+  return urls
+}
+
+const base_urls = [
   "https://data.monarchinitiative.org/monarch-kg-dev/",
   "https://data.monarchinitiative.org/monarch-kg-dev/2022-02-10/index.html",
-  "https://data.monarchinitiative.org/monarch-kg-dev/2023-04-02/index.html",
-  "https://data.monarchinitiative.org/monarch-kg-dev/2023-04-02/qc_report.yaml",
-  "https://data.monarchinitiative.org/monarch-kg-dev/2023-10-28/index.html",
-  "https://data.monarchinitiative.org/monarch-kg-dev/2023-10-28/qc_report.yaml",
   "https://data.monarchinitiative.org/monarch-kg-dev/kgx/index.html",
-  "https://data.monarchinitiative.org/monarch-kg-dev/latest/index.html",
-  "https://data.monarchinitiative.org/monarch-kg-dev/latest/qc_report.yaml",
 ]
 
+const dev_urls = createURLS(
+  "https://data.monarchinitiative.org/monarch-kg-dev/",
+  ["2023-04-02", "2023-10-28", "latest"],
+  ["index.html", "qc_report.yaml", "merged_graph_stats.yaml"]
+)
+
+const urls = base_urls.concat(dev_urls)
 const handlers = urls.map(createRequestHandler)
 const server = setupServer(...handlers)
-server.listen({ onUnhandledRequest: "error" })
+// server.listen({ onUnhandledRequest: "error" })
+server.listen({
+  onUnhandledRequest(req) {
+    throw new Error(`Unhandled request: ${req.method} ${req.url}`)
+  },
+})
 
 describe("fetchAllData tests", async () => {
   // @vitest-environment jsdom
@@ -63,18 +79,50 @@ describe("fetchAllData tests", async () => {
       readFileSync("test/mock_http/monarch-kg-dev/2023-10-28/qc_report.yaml", "utf-8")
     )
   })
+  test("fetchAllData globalStats", async () => {
+    expect(globalStats.value).toEqual(
+      new Map([
+        [
+          `2023-04-02`,
+          Promise.resolve(
+            readFileSync(
+              "test/mock_http/monarch-kg-dev/2023-04-02/merged_graph_stats.yaml",
+              "utf-8"
+            )
+          ),
+        ],
+        [
+          `2023-10-28`,
+          Promise.resolve(
+            readFileSync(
+              "test/mock_http/monarch-kg-dev/2023-10-28/merged_graph_stats.yaml",
+              "utf-8"
+            )
+          ),
+        ],
+      ])
+    )
+    expect(await globalStats.value.get("2022-02-10")).toEqual(undefined)
+    expect(await globalStats.value.get("latest")).toEqual(undefined)
+    expect(await globalStats.value.get("2023-04-02")).toEqual(
+      readFileSync("test/mock_http/monarch-kg-dev/2023-04-02/merged_graph_stats.yaml", "utf-8")
+    )
+    expect(await globalStats.value.get("2023-10-28")).toEqual(
+      readFileSync("test/mock_http/monarch-kg-dev/2023-10-28/merged_graph_stats.yaml", "utf-8")
+    )
+  })
 })
 
 describe("fetchQCReports tests", () => {
   // @vitest-environment jsdom
   test("fetchQCReports undefined", async () => {
-    const reports = await fetchQCReports(undefined)
+    const reports = await fetchQCReports(undefined, "")
     expect(reports).toEqual(new Map())
   })
 
   test("fetchQCReports deep structure test", async () => {
     const response = await fetch("https://data.monarchinitiative.org/monarch-kg-dev/")
-    const reports = await fetchQCReports(await response.text())
+    const reports = await fetchQCReports(await response.text(), "qc_report.yaml")
     expect(reports).toEqual(
       new Map([
         [

--- a/monarch-qc-dashboard/test/mock_http/monarch-kg-dev/2022-02-10/index.html
+++ b/monarch-qc-dashboard/test/mock_http/monarch-kg-dev/2022-02-10/index.html
@@ -28,9 +28,6 @@
     <h5>Files</h5>
     <ul>
       <li>
-	<a href="https://data.monarchinitiative.org/monarch-kg-dev/2022-02-10/merged_graph_stats.yaml">merged_graph_stats.yaml</a>
-      </li>
-      <li>
 	<a href="https://data.monarchinitiative.org/monarch-kg-dev/2022-02-10/monarch-kg.nt.gz">monarch-kg.nt.gz</a>
       </li>
       <li>

--- a/monarch-qc-dashboard/test/mock_http/monarch-kg-dev/2023-04-02/merged_graph_stats.yaml
+++ b/monarch-qc-dashboard/test/mock_http/monarch-kg-dev/2023-04-02/merged_graph_stats.yaml
@@ -1,0 +1,1577 @@
+edge_stats:
+  count_by_predicates:
+    biolink:active_in:
+      count: 135612
+      provided_by:
+        goa_go_annotation_edges:
+          count: 135612
+    biolink:actively_involved_in:
+      count: 678730
+      provided_by:
+        goa_go_annotation_edges:
+          count: 678730
+    biolink:acts_upstream_of:
+      count: 9280
+      provided_by:
+        goa_go_annotation_edges:
+          count: 9280
+    biolink:acts_upstream_of_negative_effect:
+      count: 164
+      provided_by:
+        goa_go_annotation_edges:
+          count: 164
+    biolink:acts_upstream_of_or_within:
+      count: 200625
+      provided_by:
+        goa_go_annotation_edges:
+          count: 200625
+    biolink:acts_upstream_of_or_within_negative_effect:
+      count: 182
+      provided_by:
+        goa_go_annotation_edges:
+          count: 182
+    biolink:acts_upstream_of_or_within_positive_effect:
+      count: 452
+      provided_by:
+        goa_go_annotation_edges:
+          count: 452
+    biolink:acts_upstream_of_positive_effect:
+      count: 297
+      provided_by:
+        goa_go_annotation_edges:
+          count: 297
+    biolink:affects_risk_for:
+      count: 702
+      provided_by:
+        omim_gene_to_disease_edges:
+          count: 702
+    biolink:colocalizes_with:
+      count: 4218
+      provided_by:
+        goa_go_annotation_edges:
+          count: 4218
+    biolink:contributes_to:
+      count: 6834
+      provided_by:
+        goa_go_annotation_edges:
+          count: 6834
+    biolink:enables:
+      count: 785128
+      provided_by:
+        goa_go_annotation_edges:
+          count: 785128
+    biolink:expressed_in:
+      count: 2027409
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 1790844
+        bgee_gene_to_expression_edges:
+          count: 236565
+    biolink:gene_associated_with_condition:
+      count: 5673
+      provided_by:
+        omim_gene_to_disease_edges:
+          count: 5673
+    biolink:has_mode_of_inheritance:
+      count: 8431
+      provided_by:
+        hpoa_disease_mode_of_inheritance_edges:
+          count: 8431
+    biolink:has_phenotype:
+      count: 941461
+      provided_by:
+        alliance_gene_to_phenotype_edges:
+          count: 298084
+        hpoa_disease_phenotype_edges:
+          count: 232442
+        hpoa_gene_to_phenotype_edges:
+          count: 268702
+        xenbase_gene_to_phenotype_edges:
+          count: 2317
+        zfin_gene_to_phenotype_edges:
+          count: 139916
+    biolink:interacts_with:
+      count: 502120
+      provided_by:
+        string_protein_links_edges:
+          count: 502120
+    biolink:located_in:
+      count: 473285
+      provided_by:
+        goa_go_annotation_edges:
+          count: 473285
+    biolink:orthologous_to:
+      count: 873929
+      provided_by:
+        panther_genome_orthologs_edges:
+          count: 873929
+    biolink:part_of:
+      count: 78316
+      provided_by:
+        goa_go_annotation_edges:
+          count: 78316
+    biolink:participates_in:
+      count: 106883
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 54899
+        reactome_gene_to_pathway_edges:
+          count: 51984
+    biolink:related_to:
+      count: 144353
+      provided_by:
+        phenio_edges:
+          count: 144353
+    biolink:subclass_of:
+      count: 351115
+      provided_by:
+        phenio_edges:
+          count: 351115
+    unknown:
+      count: 0
+  count_by_spo:
+    biolink:AnatomicalEntity-biolink:related_to-biolink:AnatomicalEntity:
+      count: 3752
+      provided_by:
+        phenio_edges:
+          count: 3752
+    biolink:AnatomicalEntity-biolink:related_to-biolink:Cell:
+      count: 431
+      provided_by:
+        phenio_edges:
+          count: 431
+    biolink:AnatomicalEntity-biolink:related_to-biolink:CellularComponent:
+      count: 32
+      provided_by:
+        phenio_edges:
+          count: 32
+    biolink:AnatomicalEntity-biolink:related_to-biolink:ChemicalEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:AnatomicalEntity-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 5631
+      provided_by:
+        phenio_edges:
+          count: 5631
+    biolink:AnatomicalEntity-biolink:related_to-biolink:MacromolecularComplexMixin:
+      count: 5
+      provided_by:
+        phenio_edges:
+          count: 5
+    biolink:AnatomicalEntity-biolink:related_to-biolink:MolecularEntity:
+      count: 15
+      provided_by:
+        phenio_edges:
+          count: 15
+    biolink:AnatomicalEntity-biolink:related_to-biolink:NamedThing:
+      count: 60
+      provided_by:
+        phenio_edges:
+          count: 60
+    biolink:AnatomicalEntity-biolink:related_to-biolink:Occurrent:
+      count: 170
+      provided_by:
+        phenio_edges:
+          count: 170
+    biolink:AnatomicalEntity-biolink:related_to-biolink:Protein:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:AnatomicalEntity-biolink:related_to-biolink:SmallMolecule:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:AnatomicalEntity-biolink:subclass_of-biolink:AnatomicalEntity:
+      count: 11146
+      provided_by:
+        phenio_edges:
+          count: 11146
+    biolink:AnatomicalEntity-biolink:subclass_of-biolink:NamedThing:
+      count: 32
+      provided_by:
+        phenio_edges:
+          count: 32
+    biolink:Cell-biolink:related_to-biolink:AnatomicalEntity:
+      count: 34883
+      provided_by:
+        phenio_edges:
+          count: 34883
+    biolink:Cell-biolink:related_to-biolink:Cell:
+      count: 2616
+      provided_by:
+        phenio_edges:
+          count: 2616
+    biolink:Cell-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 5932
+      provided_by:
+        phenio_edges:
+          count: 5932
+    biolink:Cell-biolink:related_to-biolink:Occurrent:
+      count: 474
+      provided_by:
+        phenio_edges:
+          count: 474
+    biolink:Cell-biolink:related_to-biolink:Pathway:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Cell-biolink:subclass_of-biolink:AnatomicalEntity:
+      count: 144
+      provided_by:
+        phenio_edges:
+          count: 144
+    biolink:Cell-biolink:subclass_of-biolink:Cell:
+      count: 27509
+      provided_by:
+        phenio_edges:
+          count: 27509
+    biolink:Cell-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:CellularComponent-biolink:related_to-biolink:AnatomicalEntity:
+      count: 34
+      provided_by:
+        phenio_edges:
+          count: 34
+    biolink:CellularComponent-biolink:related_to-biolink:Cell:
+      count: 3354
+      provided_by:
+        phenio_edges:
+          count: 3354
+    biolink:CellularComponent-biolink:related_to-biolink:CellularComponent:
+      count: 3994
+      provided_by:
+        phenio_edges:
+          count: 3994
+    biolink:CellularComponent-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 166
+      provided_by:
+        phenio_edges:
+          count: 166
+    biolink:CellularComponent-biolink:related_to-biolink:MacromolecularComplexMixin:
+      count: 17
+      provided_by:
+        phenio_edges:
+          count: 17
+    biolink:CellularComponent-biolink:related_to-biolink:Occurrent:
+      count: 20
+      provided_by:
+        phenio_edges:
+          count: 20
+    biolink:CellularComponent-biolink:related_to-biolink:RNAProduct:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:CellularComponent-biolink:subclass_of-biolink:AnatomicalEntity:
+      count: 2780
+      provided_by:
+        phenio_edges:
+          count: 2780
+    biolink:CellularComponent-biolink:subclass_of-biolink:CellularComponent:
+      count: 5208
+      provided_by:
+        phenio_edges:
+          count: 5208
+    biolink:ChemicalEntity-biolink:participates_in-biolink:Pathway:
+      count: 109
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 109
+    biolink:ChemicalEntity-biolink:related_to-biolink:ChemicalEntity:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:ChemicalEntity-biolink:related_to-biolink:ChemicalSubstance:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:ChemicalEntity-biolink:related_to-biolink:MolecularEntity:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:ChemicalEntity-biolink:related_to-biolink:PhenotypicQuality:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:ChemicalEntity-biolink:subclass_of-biolink:ChemicalEntity:
+      count: 105
+      provided_by:
+        phenio_edges:
+          count: 105
+    biolink:ChemicalSubstance-biolink:participates_in-biolink:Pathway:
+      count: 107
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 107
+    biolink:ChemicalSubstance-biolink:related_to-biolink:ChemicalSubstance:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:ChemicalSubstance-biolink:subclass_of-biolink:ChemicalSubstance:
+      count: 15
+      provided_by:
+        phenio_edges:
+          count: 15
+    biolink:ClinicalModifier-biolink:subclass_of-biolink:ClinicalModifier:
+      count: 170
+      provided_by:
+        phenio_edges:
+          count: 170
+    biolink:ClinicalModifier-biolink:subclass_of-biolink:PhenotypicFeature:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Disease-biolink:affects_risk_for-biolink:Disease:
+      count: 17
+      provided_by:
+        omim_gene_to_disease_edges:
+          count: 17
+    biolink:Disease-biolink:gene_associated_with_condition-biolink:Disease:
+      count: 5
+      provided_by:
+        omim_gene_to_disease_edges:
+          count: 5
+    biolink:Disease-biolink:has_mode_of_inheritance-biolink:GeneticInheritance:
+      count: 8424
+      provided_by:
+        hpoa_disease_mode_of_inheritance_edges:
+          count: 8424
+    biolink:Disease-biolink:has_phenotype-biolink:PhenotypicQuality:
+      count: 232419
+      provided_by:
+        hpoa_disease_phenotype_edges:
+          count: 232419
+    biolink:Disease-biolink:related_to-biolink:AnatomicalEntity:
+      count: 425
+      provided_by:
+        phenio_edges:
+          count: 425
+    biolink:Disease-biolink:related_to-biolink:CellularComponent:
+      count: 22
+      provided_by:
+        phenio_edges:
+          count: 22
+    biolink:Disease-biolink:related_to-biolink:ChemicalEntity:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:Disease-biolink:related_to-biolink:ClinicalModifier:
+      count: 33
+      provided_by:
+        phenio_edges:
+          count: 33
+    biolink:Disease-biolink:related_to-biolink:Disease:
+      count: 918
+      provided_by:
+        phenio_edges:
+          count: 918
+    biolink:Disease-biolink:related_to-biolink:GeneticInheritance:
+      count: 202
+      provided_by:
+        phenio_edges:
+          count: 202
+    biolink:Disease-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 2602
+      provided_by:
+        phenio_edges:
+          count: 2602
+    biolink:Disease-biolink:related_to-biolink:MacromolecularComplexMixin:
+      count: 13
+      provided_by:
+        phenio_edges:
+          count: 13
+    biolink:Disease-biolink:related_to-biolink:MolecularEntity:
+      count: 42
+      provided_by:
+        phenio_edges:
+          count: 42
+    biolink:Disease-biolink:related_to-biolink:Occurrent:
+      count: 390
+      provided_by:
+        phenio_edges:
+          count: 390
+    biolink:Disease-biolink:related_to-biolink:Onset:
+      count: 206
+      provided_by:
+        phenio_edges:
+          count: 206
+    biolink:Disease-biolink:related_to-biolink:Pathway:
+      count: 7
+      provided_by:
+        phenio_edges:
+          count: 7
+    biolink:Disease-biolink:related_to-biolink:PhenotypicQuality:
+      count: 2548
+      provided_by:
+        phenio_edges:
+          count: 2548
+    biolink:Disease-biolink:related_to-biolink:Protein:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Disease-biolink:related_to-biolink:SmallMolecule:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:Disease-biolink:subclass_of-biolink:Disease:
+      count: 38753
+      provided_by:
+        phenio_edges:
+          count: 38753
+    biolink:Gene-biolink:active_in-biolink:CellularComponent:
+      count: 135612
+      provided_by:
+        goa_go_annotation_edges:
+          count: 135612
+    biolink:Gene-biolink:actively_involved_in-biolink:Occurrent:
+      count: 637751
+      provided_by:
+        goa_go_annotation_edges:
+          count: 637751
+    biolink:Gene-biolink:actively_involved_in-biolink:Pathway:
+      count: 40979
+      provided_by:
+        goa_go_annotation_edges:
+          count: 40979
+    biolink:Gene-biolink:acts_upstream_of-biolink:Occurrent:
+      count: 8153
+      provided_by:
+        goa_go_annotation_edges:
+          count: 8153
+    biolink:Gene-biolink:acts_upstream_of-biolink:Pathway:
+      count: 1127
+      provided_by:
+        goa_go_annotation_edges:
+          count: 1127
+    biolink:Gene-biolink:acts_upstream_of_negative_effect-biolink:Occurrent:
+      count: 146
+      provided_by:
+        goa_go_annotation_edges:
+          count: 146
+    biolink:Gene-biolink:acts_upstream_of_negative_effect-biolink:Pathway:
+      count: 18
+      provided_by:
+        goa_go_annotation_edges:
+          count: 18
+    biolink:Gene-biolink:acts_upstream_of_or_within-biolink:Occurrent:
+      count: 186903
+      provided_by:
+        goa_go_annotation_edges:
+          count: 186903
+    biolink:Gene-biolink:acts_upstream_of_or_within-biolink:Pathway:
+      count: 13722
+      provided_by:
+        goa_go_annotation_edges:
+          count: 13722
+    biolink:Gene-biolink:acts_upstream_of_or_within_negative_effect-biolink:Occurrent:
+      count: 167
+      provided_by:
+        goa_go_annotation_edges:
+          count: 167
+    biolink:Gene-biolink:acts_upstream_of_or_within_negative_effect-biolink:Pathway:
+      count: 15
+      provided_by:
+        goa_go_annotation_edges:
+          count: 15
+    biolink:Gene-biolink:acts_upstream_of_or_within_positive_effect-biolink:Occurrent:
+      count: 423
+      provided_by:
+        goa_go_annotation_edges:
+          count: 423
+    biolink:Gene-biolink:acts_upstream_of_or_within_positive_effect-biolink:Pathway:
+      count: 29
+      provided_by:
+        goa_go_annotation_edges:
+          count: 29
+    biolink:Gene-biolink:acts_upstream_of_positive_effect-biolink:Occurrent:
+      count: 271
+      provided_by:
+        goa_go_annotation_edges:
+          count: 271
+    biolink:Gene-biolink:acts_upstream_of_positive_effect-biolink:Pathway:
+      count: 26
+      provided_by:
+        goa_go_annotation_edges:
+          count: 26
+    biolink:Gene-biolink:affects_risk_for-biolink:Disease:
+      count: 644
+      provided_by:
+        omim_gene_to_disease_edges:
+          count: 644
+    biolink:Gene-biolink:affects_risk_for-biolink:Gene:
+      count: 41
+      provided_by:
+        omim_gene_to_disease_edges:
+          count: 41
+    biolink:Gene-biolink:colocalizes_with-biolink:CellularComponent:
+      count: 4218
+      provided_by:
+        goa_go_annotation_edges:
+          count: 4218
+    biolink:Gene-biolink:contributes_to-biolink:Occurrent:
+      count: 6834
+      provided_by:
+        goa_go_annotation_edges:
+          count: 6834
+    biolink:Gene-biolink:enables-biolink:Occurrent:
+      count: 785128
+      provided_by:
+        goa_go_annotation_edges:
+          count: 785128
+    biolink:Gene-biolink:expressed_in-biolink:AnatomicalEntity:
+      count: 391318
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 356753
+        bgee_gene_to_expression_edges:
+          count: 34565
+    biolink:Gene-biolink:expressed_in-biolink:Cell:
+      count: 107757
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 107757
+    biolink:Gene-biolink:expressed_in-biolink:CellularComponent:
+      count: 33513
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 33513
+    biolink:Gene-biolink:expressed_in-biolink:GrossAnatomicalStructure:
+      count: 1451415
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 1249415
+        bgee_gene_to_expression_edges:
+          count: 202000
+    biolink:Gene-biolink:expressed_in-biolink:MacromolecularComplexMixin:
+      count: 6342
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 6342
+    biolink:Gene-biolink:expressed_in-biolink:NamedThing:
+      count: 37064
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 37064
+    biolink:Gene-biolink:gene_associated_with_condition-biolink:Disease:
+      count: 5585
+      provided_by:
+        omim_gene_to_disease_edges:
+          count: 5585
+    biolink:Gene-biolink:gene_associated_with_condition-biolink:Gene:
+      count: 83
+      provided_by:
+        omim_gene_to_disease_edges:
+          count: 83
+    biolink:Gene-biolink:has_mode_of_inheritance-biolink:GeneticInheritance:
+      count: 7
+      provided_by:
+        hpoa_disease_mode_of_inheritance_edges:
+          count: 7
+    biolink:Gene-biolink:has_phenotype-biolink:ClinicalModifier:
+      count: 1463
+      provided_by:
+        hpoa_gene_to_phenotype_edges:
+          count: 1463
+    biolink:Gene-biolink:has_phenotype-biolink:GeneticInheritance:
+      count: 7225
+      provided_by:
+        hpoa_gene_to_phenotype_edges:
+          count: 7225
+    biolink:Gene-biolink:has_phenotype-biolink:Onset:
+      count: 4855
+      provided_by:
+        hpoa_gene_to_phenotype_edges:
+          count: 4855
+    biolink:Gene-biolink:has_phenotype-biolink:PhenotypicFeature:
+      count: 1
+      provided_by:
+        hpoa_gene_to_phenotype_edges:
+          count: 1
+    biolink:Gene-biolink:has_phenotype-biolink:PhenotypicQuality:
+      count: 695498
+      provided_by:
+        alliance_gene_to_phenotype_edges:
+          count: 298084
+        hpoa_disease_phenotype_edges:
+          count: 23
+        hpoa_gene_to_phenotype_edges:
+          count: 255158
+        xenbase_gene_to_phenotype_edges:
+          count: 2317
+        zfin_gene_to_phenotype_edges:
+          count: 139916
+    biolink:Gene-biolink:interacts_with-biolink:Gene:
+      count: 502120
+      provided_by:
+        string_protein_links_edges:
+          count: 502120
+    biolink:Gene-biolink:located_in-biolink:CellularComponent:
+      count: 473285
+      provided_by:
+        goa_go_annotation_edges:
+          count: 473285
+    biolink:Gene-biolink:orthologous_to-biolink:Gene:
+      count: 873929
+      provided_by:
+        panther_genome_orthologs_edges:
+          count: 873929
+    biolink:Gene-biolink:part_of-biolink:MacromolecularComplexMixin:
+      count: 78316
+      provided_by:
+        goa_go_annotation_edges:
+          count: 78316
+    biolink:Gene-biolink:participates_in-biolink:Pathway:
+      count: 51984
+      provided_by:
+        reactome_gene_to_pathway_edges:
+          count: 51984
+    biolink:GeneticInheritance-biolink:subclass_of-biolink:GeneticInheritance:
+      count: 35
+      provided_by:
+        phenio_edges:
+          count: 35
+    biolink:GeneticInheritance-biolink:subclass_of-biolink:PhenotypicFeature:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:AnatomicalEntity:
+      count: 4516
+      provided_by:
+        phenio_edges:
+          count: 4516
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:Cell:
+      count: 213
+      provided_by:
+        phenio_edges:
+          count: 213
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:CellularComponent:
+      count: 29
+      provided_by:
+        phenio_edges:
+          count: 29
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 20963
+      provided_by:
+        phenio_edges:
+          count: 20963
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:MacromolecularComplexMixin:
+      count: 6
+      provided_by:
+        phenio_edges:
+          count: 6
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:MolecularEntity:
+      count: 9
+      provided_by:
+        phenio_edges:
+          count: 9
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:NamedThing:
+      count: 289
+      provided_by:
+        phenio_edges:
+          count: 289
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:Occurrent:
+      count: 335
+      provided_by:
+        phenio_edges:
+          count: 335
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:SmallMolecule:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:AnatomicalEntity:
+      count: 3003
+      provided_by:
+        phenio_edges:
+          count: 3003
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:Cell:
+      count: 106
+      provided_by:
+        phenio_edges:
+          count: 106
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:CellularComponent:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:GrossAnatomicalStructure:
+      count: 32268
+      provided_by:
+        phenio_edges:
+          count: 32268
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:NamedThing:
+      count: 104
+      provided_by:
+        phenio_edges:
+          count: 104
+    biolink:MacromolecularComplexMixin-biolink:related_to-biolink:CellularComponent:
+      count: 592
+      provided_by:
+        phenio_edges:
+          count: 592
+    biolink:MacromolecularComplexMixin-biolink:related_to-biolink:MacromolecularComplexMixin:
+      count: 253
+      provided_by:
+        phenio_edges:
+          count: 253
+    biolink:MacromolecularComplexMixin-biolink:related_to-biolink:MolecularEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:MacromolecularComplexMixin-biolink:related_to-biolink:Occurrent:
+      count: 64
+      provided_by:
+        phenio_edges:
+          count: 64
+    biolink:MacromolecularComplexMixin-biolink:related_to-biolink:Pathway:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:MacromolecularComplexMixin-biolink:related_to-biolink:RNAProduct:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:MacromolecularComplexMixin-biolink:subclass_of-biolink:CellularComponent:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:MacromolecularComplexMixin-biolink:subclass_of-biolink:MacromolecularComplexMixin:
+      count: 2614
+      provided_by:
+        phenio_edges:
+          count: 2614
+    biolink:MolecularEntity-biolink:participates_in-biolink:Pathway:
+      count: 53233
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 53233
+    biolink:MolecularEntity-biolink:related_to-biolink:ChemicalEntity:
+      count: 55
+      provided_by:
+        phenio_edges:
+          count: 55
+    biolink:MolecularEntity-biolink:related_to-biolink:MolecularEntity:
+      count: 2143
+      provided_by:
+        phenio_edges:
+          count: 2143
+    biolink:MolecularEntity-biolink:related_to-biolink:PhenotypicQuality:
+      count: 371
+      provided_by:
+        phenio_edges:
+          count: 371
+    biolink:MolecularEntity-biolink:related_to-biolink:SmallMolecule:
+      count: 7
+      provided_by:
+        phenio_edges:
+          count: 7
+    biolink:MolecularEntity-biolink:subclass_of-biolink:ChemicalEntity:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:MolecularEntity-biolink:subclass_of-biolink:MolecularEntity:
+      count: 5620
+      provided_by:
+        phenio_edges:
+          count: 5620
+    biolink:NamedThing-biolink:related_to-biolink:AnatomicalEntity:
+      count: 382
+      provided_by:
+        phenio_edges:
+          count: 382
+    biolink:NamedThing-biolink:related_to-biolink:Cell:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:NamedThing-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 1602
+      provided_by:
+        phenio_edges:
+          count: 1602
+    biolink:NamedThing-biolink:related_to-biolink:NamedThing:
+      count: 573
+      provided_by:
+        phenio_edges:
+          count: 573
+    biolink:NamedThing-biolink:subclass_of-biolink:NamedThing:
+      count: 329
+      provided_by:
+        phenio_edges:
+          count: 329
+    biolink:Occurrent-biolink:related_to-biolink:AnatomicalEntity:
+      count: 276
+      provided_by:
+        phenio_edges:
+          count: 276
+    biolink:Occurrent-biolink:related_to-biolink:CellularComponent:
+      count: 1320
+      provided_by:
+        phenio_edges:
+          count: 1320
+    biolink:Occurrent-biolink:related_to-biolink:ChemicalEntity:
+      count: 5
+      provided_by:
+        phenio_edges:
+          count: 5
+    biolink:Occurrent-biolink:related_to-biolink:ChemicalSubstance:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Occurrent-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 848
+      provided_by:
+        phenio_edges:
+          count: 848
+    biolink:Occurrent-biolink:related_to-biolink:MacromolecularComplexMixin:
+      count: 68
+      provided_by:
+        phenio_edges:
+          count: 68
+    biolink:Occurrent-biolink:related_to-biolink:MolecularEntity:
+      count: 2009
+      provided_by:
+        phenio_edges:
+          count: 2009
+    biolink:Occurrent-biolink:related_to-biolink:Occurrent:
+      count: 15470
+      provided_by:
+        phenio_edges:
+          count: 15470
+    biolink:Occurrent-biolink:related_to-biolink:Pathway:
+      count: 910
+      provided_by:
+        phenio_edges:
+          count: 910
+    biolink:Occurrent-biolink:related_to-biolink:Protein:
+      count: 38
+      provided_by:
+        phenio_edges:
+          count: 38
+    biolink:Occurrent-biolink:related_to-biolink:RNAProduct:
+      count: 25
+      provided_by:
+        phenio_edges:
+          count: 25
+    biolink:Occurrent-biolink:related_to-biolink:SmallMolecule:
+      count: 7
+      provided_by:
+        phenio_edges:
+          count: 7
+    biolink:Occurrent-biolink:subclass_of-biolink:Occurrent:
+      count: 77709
+      provided_by:
+        phenio_edges:
+          count: 77709
+    biolink:Onset-biolink:subclass_of-biolink:ClinicalModifier:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Onset-biolink:subclass_of-biolink:Onset:
+      count: 20
+      provided_by:
+        phenio_edges:
+          count: 20
+    biolink:PathologicalEntityMixin-biolink:related_to-biolink:PathologicalEntityMixin:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:PathologicalEntityMixin-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:PathologicalEntityMixin-biolink:subclass_of-biolink:PathologicalEntityMixin:
+      count: 944
+      provided_by:
+        phenio_edges:
+          count: 944
+    biolink:Pathway-biolink:related_to-biolink:CellularComponent:
+      count: 7
+      provided_by:
+        phenio_edges:
+          count: 7
+    biolink:Pathway-biolink:related_to-biolink:MolecularEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Pathway-biolink:related_to-biolink:Occurrent:
+      count: 352
+      provided_by:
+        phenio_edges:
+          count: 352
+    biolink:Pathway-biolink:related_to-biolink:Pathway:
+      count: 17
+      provided_by:
+        phenio_edges:
+          count: 17
+    biolink:Pathway-biolink:subclass_of-biolink:Occurrent:
+      count: 133
+      provided_by:
+        phenio_edges:
+          count: 133
+    biolink:Pathway-biolink:subclass_of-biolink:Pathway:
+      count: 894
+      provided_by:
+        phenio_edges:
+          count: 894
+    biolink:PhenotypicFeature-biolink:subclass_of-biolink:PhenotypicFeature:
+      count: 35
+      provided_by:
+        phenio_edges:
+          count: 35
+    biolink:PhenotypicQuality-biolink:participates_in-biolink:Pathway:
+      count: 10
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 10
+    biolink:PhenotypicQuality-biolink:related_to-biolink:AnatomicalEntity:
+      count: 2599
+      provided_by:
+        phenio_edges:
+          count: 2599
+    biolink:PhenotypicQuality-biolink:related_to-biolink:BiologicalProcess:
+      count: 19
+      provided_by:
+        phenio_edges:
+          count: 19
+    biolink:PhenotypicQuality-biolink:related_to-biolink:Cell:
+      count: 109
+      provided_by:
+        phenio_edges:
+          count: 109
+    biolink:PhenotypicQuality-biolink:related_to-biolink:CellularComponent:
+      count: 2431
+      provided_by:
+        phenio_edges:
+          count: 2431
+    biolink:PhenotypicQuality-biolink:related_to-biolink:ChemicalEntity:
+      count: 67
+      provided_by:
+        phenio_edges:
+          count: 67
+    biolink:PhenotypicQuality-biolink:related_to-biolink:ChemicalSubstance:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:PhenotypicQuality-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 7565
+      provided_by:
+        phenio_edges:
+          count: 7565
+    biolink:PhenotypicQuality-biolink:related_to-biolink:MacromolecularComplexMixin:
+      count: 255
+      provided_by:
+        phenio_edges:
+          count: 255
+    biolink:PhenotypicQuality-biolink:related_to-biolink:MolecularEntity:
+      count: 867
+      provided_by:
+        phenio_edges:
+          count: 867
+    biolink:PhenotypicQuality-biolink:related_to-biolink:NamedThing:
+      count: 32
+      provided_by:
+        phenio_edges:
+          count: 32
+    biolink:PhenotypicQuality-biolink:related_to-biolink:Occurrent:
+      count: 4563
+      provided_by:
+        phenio_edges:
+          count: 4563
+    biolink:PhenotypicQuality-biolink:related_to-biolink:PathologicalEntityMixin:
+      count: 342
+      provided_by:
+        phenio_edges:
+          count: 342
+    biolink:PhenotypicQuality-biolink:related_to-biolink:Pathway:
+      count: 134
+      provided_by:
+        phenio_edges:
+          count: 134
+    biolink:PhenotypicQuality-biolink:related_to-biolink:PhenotypicQuality:
+      count: 35
+      provided_by:
+        phenio_edges:
+          count: 35
+    biolink:PhenotypicQuality-biolink:related_to-biolink:Protein:
+      count: 33
+      provided_by:
+        phenio_edges:
+          count: 33
+    biolink:PhenotypicQuality-biolink:related_to-biolink:RNAProduct:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:PhenotypicQuality-biolink:related_to-biolink:SmallMolecule:
+      count: 19
+      provided_by:
+        phenio_edges:
+          count: 19
+    biolink:PhenotypicQuality-biolink:subclass_of-biolink:PhenotypicFeature:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:PhenotypicQuality-biolink:subclass_of-biolink:PhenotypicQuality:
+      count: 140748
+      provided_by:
+        phenio_edges:
+          count: 140748
+    biolink:Protein-biolink:participates_in-biolink:Pathway:
+      count: 602
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 602
+    biolink:Protein-biolink:related_to-biolink:MolecularEntity:
+      count: 6
+      provided_by:
+        phenio_edges:
+          count: 6
+    biolink:Protein-biolink:related_to-biolink:Protein:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Protein-biolink:subclass_of-biolink:MolecularEntity:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:Protein-biolink:subclass_of-biolink:Protein:
+      count: 20
+      provided_by:
+        phenio_edges:
+          count: 20
+    biolink:RNAProduct-biolink:participates_in-biolink:Pathway:
+      count: 628
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 628
+    biolink:RNAProduct-biolink:related_to-biolink:MolecularEntity:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:RNAProduct-biolink:subclass_of-biolink:MolecularEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:RNAProduct-biolink:subclass_of-biolink:RNAProduct:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:SmallMolecule-biolink:participates_in-biolink:Pathway:
+      count: 46
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 46
+    biolink:SmallMolecule-biolink:related_to-biolink:MolecularEntity:
+      count: 88
+      provided_by:
+        phenio_edges:
+          count: 88
+    biolink:SmallMolecule-biolink:related_to-biolink:PhenotypicQuality:
+      count: 21
+      provided_by:
+        phenio_edges:
+          count: 21
+    biolink:SmallMolecule-biolink:related_to-biolink:SmallMolecule:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:SmallMolecule-biolink:subclass_of-biolink:ChemicalEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:SmallMolecule-biolink:subclass_of-biolink:MolecularEntity:
+      count: 51
+      provided_by:
+        phenio_edges:
+          count: 51
+    biolink:SmallMolecule-biolink:subclass_of-biolink:SmallMolecule:
+      count: 57
+      provided_by:
+        phenio_edges:
+          count: 57
+  predicates:
+  - biolink:active_in
+  - biolink:actively_involved_in
+  - biolink:acts_upstream_of
+  - biolink:acts_upstream_of_negative_effect
+  - biolink:acts_upstream_of_or_within
+  - biolink:acts_upstream_of_or_within_negative_effect
+  - biolink:acts_upstream_of_or_within_positive_effect
+  - biolink:acts_upstream_of_positive_effect
+  - biolink:affects_risk_for
+  - biolink:colocalizes_with
+  - biolink:contributes_to
+  - biolink:enables
+  - biolink:expressed_in
+  - biolink:gene_associated_with_condition
+  - biolink:has_mode_of_inheritance
+  - biolink:has_phenotype
+  - biolink:interacts_with
+  - biolink:located_in
+  - biolink:orthologous_to
+  - biolink:part_of
+  - biolink:participates_in
+  - biolink:related_to
+  - biolink:subclass_of
+  provided_by:
+  - alliance_gene_to_expression_edges
+  - alliance_gene_to_phenotype_edges
+  - bgee_gene_to_expression_edges
+  - goa_go_annotation_edges
+  - hpoa_disease_mode_of_inheritance_edges
+  - hpoa_disease_phenotype_edges
+  - hpoa_gene_to_phenotype_edges
+  - omim_gene_to_disease_edges
+  - panther_genome_orthologs_edges
+  - phenio_edges
+  - reactome_chemical_to_pathway_edges
+  - reactome_gene_to_pathway_edges
+  - string_protein_links_edges
+  - xenbase_gene_to_phenotype_edges
+  - zfin_gene_to_phenotype_edges
+  total_edges: 7335199
+graph_name: Graph
+node_stats:
+  count_by_category:
+    biolink:AnatomicalEntity:
+      count: 9880
+      provided_by:
+        phenio_nodes:
+          count: 9880
+    biolink:BiologicalProcess:
+      count: 2553
+      provided_by:
+        phenio_nodes:
+          count: 2553
+    biolink:Cell:
+      count: 15719
+      provided_by:
+        phenio_nodes:
+          count: 15719
+    biolink:CellularComponent:
+      count: 5276
+      provided_by:
+        phenio_nodes:
+          count: 5276
+    biolink:ChemicalEntity:
+      count: 76
+      provided_by:
+        phenio_nodes:
+          count: 76
+    biolink:ChemicalSubstance:
+      count: 14
+      provided_by:
+        phenio_nodes:
+          count: 14
+    biolink:ClinicalModifier:
+      count: 171
+      provided_by:
+        phenio_nodes:
+          count: 171
+    biolink:Disease:
+      count: 25951
+      provided_by:
+        phenio_nodes:
+          count: 25951
+    biolink:Gene:
+      count: 566806
+      provided_by:
+        alliance_gene_nodes:
+          count: 309111
+        dictybase_gene_nodes:
+          count: 14222
+        hgnc_gene_nodes:
+          count: 43624
+        ncbi_gene_nodes:
+          count: 194715
+        pombase_gene_nodes:
+          count: 5134
+    biolink:GeneticInheritance:
+      count: 33
+      provided_by:
+        phenio_nodes:
+          count: 33
+    biolink:GrossAnatomicalStructure:
+      count: 21753
+      provided_by:
+        phenio_nodes:
+          count: 21753
+    biolink:MacromolecularComplexMixin:
+      count: 2100
+      provided_by:
+        phenio_nodes:
+          count: 2100
+    biolink:MolecularActivity:
+      count: 1175
+      provided_by:
+        phenio_nodes:
+          count: 1175
+    biolink:MolecularEntity:
+      count: 3395
+      provided_by:
+        phenio_nodes:
+          count: 3395
+    biolink:NamedThing:
+      count: 9099
+      provided_by:
+        phenio_nodes:
+          count: 9099
+    biolink:Occurrent:
+      count: 38565
+      provided_by:
+        phenio_nodes:
+          count: 38565
+    biolink:Onset:
+      count: 21
+      provided_by:
+        phenio_nodes:
+          count: 21
+    biolink:PathologicalEntityMixin:
+      count: 839
+      provided_by:
+        phenio_nodes:
+          count: 839
+    biolink:Pathway:
+      count: 22144
+      provided_by:
+        phenio_nodes:
+          count: 717
+        reactome_pathway_nodes:
+          count: 21427
+    biolink:PhenotypicFeature:
+      count: 368
+      provided_by:
+        phenio_nodes:
+          count: 368
+    biolink:PhenotypicQuality:
+      count: 89435
+      provided_by:
+        phenio_nodes:
+          count: 89435
+    biolink:Protein:
+      count: 21
+      provided_by:
+        phenio_nodes:
+          count: 21
+    biolink:RNAProduct:
+      count: 3
+      provided_by:
+        phenio_nodes:
+          count: 3
+    biolink:SmallMolecule:
+      count: 57
+      provided_by:
+        phenio_nodes:
+          count: 57
+    unknown:
+      count: 0
+  count_by_id_prefixes:
+    CHEBI: 3697
+    EMAPA: 8745
+    FB: 30254
+    FBbt: 19918
+    FYPO: 1
+    GO: 51063
+    HGNC: 43624
+    HP: 16954
+    MESH: 2
+    MGI: 79302
+    MONDO: 25990
+    MP: 14049
+    MPATH: 891
+    NCBIGene: 194715
+    PomBase: 5134
+    REACT: 21427
+    RGD: 66867
+    SGD: 7153
+    UBERON: 15779
+    WB: 48774
+    WBPhenotype: 2695
+    WBbt: 7556
+    XPO: 20061
+    Xenbase: 38752
+    ZFA: 3218
+    ZFIN: 38009
+    ZP: 36602
+    dictyBase: 14222
+  count_by_id_prefixes_by_category:
+    biolink:AnatomicalEntity:
+      EMAPA: 1119
+      FBbt: 2290
+      UBERON: 5432
+      WBbt: 141
+      ZFA: 898
+    biolink:BiologicalProcess:
+      GO: 2553
+    biolink:Cell:
+      EMAPA: 5
+      FBbt: 12324
+      GO: 1
+      WBbt: 3388
+      ZFA: 1
+    biolink:CellularComponent:
+      GO: 2368
+      WBbt: 2908
+    biolink:ChemicalEntity:
+      CHEBI: 76
+    biolink:ChemicalSubstance:
+      CHEBI: 14
+    biolink:ClinicalModifier:
+      HP: 171
+    biolink:Disease:
+      MESH: 2
+      MONDO: 25949
+    biolink:Gene:
+      FB: 30254
+      HGNC: 43624
+      MGI: 79302
+      NCBIGene: 194715
+      PomBase: 5134
+      RGD: 66867
+      SGD: 7153
+      WB: 48774
+      Xenbase: 38752
+      ZFIN: 38009
+      dictyBase: 14222
+    biolink:GeneticInheritance:
+      HP: 33
+    biolink:GrossAnatomicalStructure:
+      EMAPA: 4746
+      FBbt: 4193
+      UBERON: 10287
+      WBbt: 326
+      ZFA: 2201
+    biolink:MacromolecularComplexMixin:
+      GO: 2100
+    biolink:MolecularActivity:
+      GO: 1175
+    biolink:MolecularEntity:
+      CHEBI: 3395
+    biolink:NamedThing:
+      EMAPA: 2875
+      FBbt: 1111
+      GO: 3644
+      MP: 444
+      MPATH: 52
+      WBPhenotype: 62
+      WBbt: 793
+      ZFA: 118
+    biolink:Occurrent:
+      GO: 38505
+      UBERON: 60
+    biolink:Onset:
+      HP: 21
+    biolink:PathologicalEntityMixin:
+      MPATH: 839
+    biolink:Pathway:
+      GO: 717
+      REACT: 21427
+    biolink:PhenotypicFeature:
+      FYPO: 1
+      HP: 367
+    biolink:PhenotypicQuality:
+      CHEBI: 131
+      HP: 16362
+      MONDO: 41
+      MP: 13605
+      WBPhenotype: 2633
+      XPO: 20061
+      ZP: 36602
+    biolink:Protein:
+      CHEBI: 21
+    biolink:RNAProduct:
+      CHEBI: 3
+    biolink:SmallMolecule:
+      CHEBI: 57
+    unknown: {}
+  node_categories:
+  - biolink:AnatomicalEntity
+  - biolink:BiologicalProcess
+  - biolink:Cell
+  - biolink:CellularComponent
+  - biolink:ChemicalEntity
+  - biolink:ChemicalSubstance
+  - biolink:ClinicalModifier
+  - biolink:Disease
+  - biolink:Gene
+  - biolink:GeneticInheritance
+  - biolink:GrossAnatomicalStructure
+  - biolink:MacromolecularComplexMixin
+  - biolink:MolecularActivity
+  - biolink:MolecularEntity
+  - biolink:NamedThing
+  - biolink:Occurrent
+  - biolink:Onset
+  - biolink:PathologicalEntityMixin
+  - biolink:Pathway
+  - biolink:PhenotypicFeature
+  - biolink:PhenotypicQuality
+  - biolink:Protein
+  - biolink:RNAProduct
+  - biolink:SmallMolecule
+  node_id_prefixes:
+  - CHEBI
+  - EMAPA
+  - FB
+  - FBbt
+  - FYPO
+  - GO
+  - HGNC
+  - HP
+  - MESH
+  - MGI
+  - MONDO
+  - MP
+  - MPATH
+  - NCBIGene
+  - PomBase
+  - REACT
+  - RGD
+  - SGD
+  - UBERON
+  - WB
+  - WBPhenotype
+  - WBbt
+  - XPO
+  - Xenbase
+  - ZFA
+  - ZFIN
+  - ZP
+  - dictyBase
+  node_id_prefixes_by_category:
+    biolink:AnatomicalEntity:
+    - EMAPA
+    - FBbt
+    - UBERON
+    - WBbt
+    - ZFA
+    biolink:BiologicalProcess:
+    - GO
+    biolink:Cell:
+    - EMAPA
+    - FBbt
+    - GO
+    - WBbt
+    - ZFA
+    biolink:CellularComponent:
+    - GO
+    - WBbt
+    biolink:ChemicalEntity:
+    - CHEBI
+    biolink:ChemicalSubstance:
+    - CHEBI
+    biolink:ClinicalModifier:
+    - HP
+    biolink:Disease:
+    - MESH
+    - MONDO
+    biolink:Gene:
+    - PomBase
+    - HGNC
+    - ZFIN
+    - Xenbase
+    - WB
+    - SGD
+    - RGD
+    - MGI
+    - FB
+    - NCBIGene
+    - dictyBase
+    biolink:GeneticInheritance:
+    - HP
+    biolink:GrossAnatomicalStructure:
+    - EMAPA
+    - FBbt
+    - UBERON
+    - WBbt
+    - ZFA
+    biolink:MacromolecularComplexMixin:
+    - GO
+    biolink:MolecularActivity:
+    - GO
+    biolink:MolecularEntity:
+    - CHEBI
+    biolink:NamedThing:
+    - EMAPA
+    - FBbt
+    - GO
+    - MPATH
+    - MP
+    - WBPhenotype
+    - WBbt
+    - ZFA
+    biolink:Occurrent:
+    - GO
+    - UBERON
+    biolink:Onset:
+    - HP
+    biolink:PathologicalEntityMixin:
+    - MPATH
+    biolink:Pathway:
+    - REACT
+    - GO
+    biolink:PhenotypicFeature:
+    - FYPO
+    - HP
+    biolink:PhenotypicQuality:
+    - CHEBI
+    - HP
+    - MONDO
+    - MP
+    - WBPhenotype
+    - XPO
+    - ZP
+    biolink:Protein:
+    - CHEBI
+    biolink:RNAProduct:
+    - CHEBI
+    biolink:SmallMolecule:
+    - CHEBI
+    unknown: []
+  provided_by:
+  - alliance_gene_nodes
+  - dictybase_gene_nodes
+  - hgnc_gene_nodes
+  - ncbi_gene_nodes
+  - phenio_nodes
+  - pombase_gene_nodes
+  - reactome_pathway_nodes
+  total_nodes: 815965

--- a/monarch-qc-dashboard/test/mock_http/monarch-kg-dev/2023-10-28/merged_graph_stats.yaml
+++ b/monarch-qc-dashboard/test/mock_http/monarch-kg-dev/2023-10-28/merged_graph_stats.yaml
@@ -1,0 +1,3165 @@
+edge_stats:
+  count_by_predicates:
+    biolink:active_in:
+      count: 142559
+      provided_by:
+        goa_go_annotation_edges:
+          count: 142559
+    biolink:actively_involved_in:
+      count: 797104
+      provided_by:
+        goa_go_annotation_edges:
+          count: 797104
+    biolink:acts_upstream_of:
+      count: 9352
+      provided_by:
+        goa_go_annotation_edges:
+          count: 9352
+    biolink:acts_upstream_of_negative_effect:
+      count: 173
+      provided_by:
+        goa_go_annotation_edges:
+          count: 173
+    biolink:acts_upstream_of_or_within:
+      count: 179862
+      provided_by:
+        goa_go_annotation_edges:
+          count: 179862
+    biolink:acts_upstream_of_or_within_negative_effect:
+      count: 178
+      provided_by:
+        goa_go_annotation_edges:
+          count: 178
+    biolink:acts_upstream_of_or_within_positive_effect:
+      count: 504
+      provided_by:
+        goa_go_annotation_edges:
+          count: 504
+    biolink:acts_upstream_of_positive_effect:
+      count: 359
+      provided_by:
+        goa_go_annotation_edges:
+          count: 359
+    biolink:affects:
+      count: 276
+      provided_by:
+        ctd_chemical_to_disease_edges:
+          count: 276
+    biolink:causes:
+      count: 6496
+      provided_by:
+        hpoa_gene_to_disease_edges:
+          count: 6496
+    biolink:colocalizes_with:
+      count: 4046
+      provided_by:
+        goa_go_annotation_edges:
+          count: 4046
+    biolink:contributes_to:
+      count: 7443
+      provided_by:
+        goa_go_annotation_edges:
+          count: 6853
+        hpoa_gene_to_disease_edges:
+          count: 590
+    biolink:enables:
+      count: 838104
+      provided_by:
+        goa_go_annotation_edges:
+          count: 838104
+    biolink:expressed_in:
+      count: 2096237
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 1849108
+        bgee_gene_to_expression_edges:
+          count: 247129
+    biolink:gene_associated_with_condition:
+      count: 7946
+      provided_by:
+        hpoa_gene_to_disease_edges:
+          count: 7946
+    biolink:has_mode_of_inheritance:
+      count: 8416
+      provided_by:
+        hpoa_disease_mode_of_inheritance_edges:
+          count: 8416
+    biolink:has_phenotype:
+      count: 1122612
+      provided_by:
+        alliance_gene_to_phenotype_edges:
+          count: 300166
+        hpoa_disease_to_phenotype_edges:
+          count: 240274
+        hpoa_gene_to_phenotype_edges:
+          count: 297505
+        pombase_gene_to_phenotype_edges:
+          count: 139030
+        xenbase_gene_to_phenotype_edges:
+          count: 2314
+        zfin_gene_to_phenotype_edges:
+          count: 143323
+    biolink:interacts_with:
+      count: 2760204
+      provided_by:
+        string_protein_links_edges:
+          count: 2760204
+    biolink:located_in:
+      count: 498461
+      provided_by:
+        goa_go_annotation_edges:
+          count: 498461
+    biolink:orthologous_to:
+      count: 550848
+      provided_by:
+        panther_genome_orthologs_edges:
+          count: 550848
+    biolink:part_of:
+      count: 92927
+      provided_by:
+        goa_go_annotation_edges:
+          count: 92927
+    biolink:participates_in:
+      count: 256195
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 63850
+        reactome_gene_to_pathway_edges:
+          count: 192345
+    biolink:related_to:
+      count: 208785
+      provided_by:
+        phenio_edges:
+          count: 208785
+    biolink:subclass_of:
+      count: 460809
+      provided_by:
+        phenio_edges:
+          count: 460809
+    unknown:
+      count: 0
+  count_by_spo:
+    biolink:AnatomicalEntity-biolink:related_to-biolink:AnatomicalEntity:
+      count: 3753
+      provided_by:
+        phenio_edges:
+          count: 3753
+    biolink:AnatomicalEntity-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 171
+      provided_by:
+        phenio_edges:
+          count: 171
+    biolink:AnatomicalEntity-biolink:related_to-biolink:Cell:
+      count: 522
+      provided_by:
+        phenio_edges:
+          count: 522
+    biolink:AnatomicalEntity-biolink:related_to-biolink:CellularComponent:
+      count: 32
+      provided_by:
+        phenio_edges:
+          count: 32
+    biolink:AnatomicalEntity-biolink:related_to-biolink:CellularOrganism:
+      count: 210
+      provided_by:
+        phenio_edges:
+          count: 210
+    biolink:AnatomicalEntity-biolink:related_to-biolink:ChemicalEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:AnatomicalEntity-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 5641
+      provided_by:
+        phenio_edges:
+          count: 5641
+    biolink:AnatomicalEntity-biolink:related_to-biolink:MacromolecularComplex:
+      count: 5
+      provided_by:
+        phenio_edges:
+          count: 5
+    biolink:AnatomicalEntity-biolink:related_to-biolink:MolecularEntity:
+      count: 15
+      provided_by:
+        phenio_edges:
+          count: 15
+    biolink:AnatomicalEntity-biolink:related_to-biolink:NamedThing:
+      count: 3199
+      provided_by:
+        phenio_edges:
+          count: 3199
+    biolink:AnatomicalEntity-biolink:related_to-biolink:Protein:
+      count: 9
+      provided_by:
+        phenio_edges:
+          count: 9
+    biolink:AnatomicalEntity-biolink:related_to-biolink:SmallMolecule:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:AnatomicalEntity-biolink:related_to-biolink:Vertebrate:
+      count: 3636
+      provided_by:
+        phenio_edges:
+          count: 3636
+    biolink:AnatomicalEntity-biolink:subclass_of-biolink:AnatomicalEntity:
+      count: 13479
+      provided_by:
+        phenio_edges:
+          count: 13479
+    biolink:AnatomicalEntity-biolink:subclass_of-biolink:Cell:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:AnatomicalEntity-biolink:subclass_of-biolink:NamedThing:
+      count: 72
+      provided_by:
+        phenio_edges:
+          count: 72
+    biolink:AnatomicalEntity-biolink:subclass_of-biolink:Protein:
+      count: 31
+      provided_by:
+        phenio_edges:
+          count: 31
+    biolink:BehavioralFeature-biolink:subclass_of-biolink:BehavioralFeature:
+      count: 306
+      provided_by:
+        phenio_edges:
+          count: 306
+    biolink:BehavioralFeature-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:AnatomicalEntity:
+      count: 276
+      provided_by:
+        phenio_edges:
+          count: 276
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 15258
+      provided_by:
+        phenio_edges:
+          count: 15258
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:Cell:
+      count: 850
+      provided_by:
+        phenio_edges:
+          count: 850
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:CellularComponent:
+      count: 1361
+      provided_by:
+        phenio_edges:
+          count: 1361
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:CellularOrganism:
+      count: 180
+      provided_by:
+        phenio_edges:
+          count: 180
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:ChemicalEntity:
+      count: 22
+      provided_by:
+        phenio_edges:
+          count: 22
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 854
+      provided_by:
+        phenio_edges:
+          count: 854
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:InformationContentEntity:
+      count: 20
+      provided_by:
+        phenio_edges:
+          count: 20
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:MacromolecularComplex:
+      count: 109
+      provided_by:
+        phenio_edges:
+          count: 109
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:MolecularEntity:
+      count: 2578
+      provided_by:
+        phenio_edges:
+          count: 2578
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:NamedThing:
+      count: 67
+      provided_by:
+        phenio_edges:
+          count: 67
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:Pathway:
+      count: 893
+      provided_by:
+        phenio_edges:
+          count: 893
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:Plant:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:Protein:
+      count: 221
+      provided_by:
+        phenio_edges:
+          count: 221
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:RNAProduct:
+      count: 28
+      provided_by:
+        phenio_edges:
+          count: 28
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:SmallMolecule:
+      count: 18
+      provided_by:
+        phenio_edges:
+          count: 18
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:Transcript:
+      count: 6
+      provided_by:
+        phenio_edges:
+          count: 6
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:Vertebrate:
+      count: 35
+      provided_by:
+        phenio_edges:
+          count: 35
+    biolink:BiologicalProcessOrActivity-biolink:related_to-biolink:Virus:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:BiologicalProcessOrActivity-biolink:subclass_of-biolink:BiologicalProcessOrActivity:
+      count: 77689
+      provided_by:
+        phenio_edges:
+          count: 77689
+    biolink:BiologicalProcessOrActivity-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Cell-biolink:related_to-biolink:AnatomicalEntity:
+      count: 34527
+      provided_by:
+        phenio_edges:
+          count: 34527
+    biolink:Cell-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 794
+      provided_by:
+        phenio_edges:
+          count: 794
+    biolink:Cell-biolink:related_to-biolink:Cell:
+      count: 2924
+      provided_by:
+        phenio_edges:
+          count: 2924
+    biolink:Cell-biolink:related_to-biolink:CellularComponent:
+      count: 36
+      provided_by:
+        phenio_edges:
+          count: 36
+    biolink:Cell-biolink:related_to-biolink:CellularOrganism:
+      count: 110
+      provided_by:
+        phenio_edges:
+          count: 110
+    biolink:Cell-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 6759
+      provided_by:
+        phenio_edges:
+          count: 6759
+    biolink:Cell-biolink:related_to-biolink:MacromolecularComplex:
+      count: 127
+      provided_by:
+        phenio_edges:
+          count: 127
+    biolink:Cell-biolink:related_to-biolink:NamedThing:
+      count: 717
+      provided_by:
+        phenio_edges:
+          count: 717
+    biolink:Cell-biolink:related_to-biolink:Pathway:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Cell-biolink:related_to-biolink:Protein:
+      count: 961
+      provided_by:
+        phenio_edges:
+          count: 961
+    biolink:Cell-biolink:related_to-biolink:Vertebrate:
+      count: 506
+      provided_by:
+        phenio_edges:
+          count: 506
+    biolink:Cell-biolink:subclass_of-biolink:AnatomicalEntity:
+      count: 148
+      provided_by:
+        phenio_edges:
+          count: 148
+    biolink:Cell-biolink:subclass_of-biolink:Cell:
+      count: 31474
+      provided_by:
+        phenio_edges:
+          count: 31474
+    biolink:Cell-biolink:subclass_of-biolink:NamedThing:
+      count: 28
+      provided_by:
+        phenio_edges:
+          count: 28
+    biolink:Cell-biolink:subclass_of-biolink:Protein:
+      count: 63
+      provided_by:
+        phenio_edges:
+          count: 63
+    biolink:CellularComponent-biolink:related_to-biolink:AnatomicalEntity:
+      count: 34
+      provided_by:
+        phenio_edges:
+          count: 34
+    biolink:CellularComponent-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 20
+      provided_by:
+        phenio_edges:
+          count: 20
+    biolink:CellularComponent-biolink:related_to-biolink:Cell:
+      count: 3420
+      provided_by:
+        phenio_edges:
+          count: 3420
+    biolink:CellularComponent-biolink:related_to-biolink:CellularComponent:
+      count: 3983
+      provided_by:
+        phenio_edges:
+          count: 3983
+    biolink:CellularComponent-biolink:related_to-biolink:CellularOrganism:
+      count: 23
+      provided_by:
+        phenio_edges:
+          count: 23
+    biolink:CellularComponent-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 166
+      provided_by:
+        phenio_edges:
+          count: 166
+    biolink:CellularComponent-biolink:related_to-biolink:MacromolecularComplex:
+      count: 23
+      provided_by:
+        phenio_edges:
+          count: 23
+    biolink:CellularComponent-biolink:related_to-biolink:NamedThing:
+      count: 9
+      provided_by:
+        phenio_edges:
+          count: 9
+    biolink:CellularComponent-biolink:related_to-biolink:NucleicAcidEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:CellularComponent-biolink:related_to-biolink:RNAProduct:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:CellularComponent-biolink:subclass_of-biolink:AnatomicalEntity:
+      count: 2781
+      provided_by:
+        phenio_edges:
+          count: 2781
+    biolink:CellularComponent-biolink:subclass_of-biolink:CellularComponent:
+      count: 5201
+      provided_by:
+        phenio_edges:
+          count: 5201
+    biolink:CellularComponent-biolink:subclass_of-biolink:NamedThing:
+      count: 2767
+      provided_by:
+        phenio_edges:
+          count: 2767
+    biolink:CellularComponent-biolink:subclass_of-biolink:Protein:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:CellularOrganism-biolink:subclass_of-biolink:CellularOrganism:
+      count: 963
+      provided_by:
+        phenio_edges:
+          count: 963
+    biolink:CellularOrganism-biolink:subclass_of-biolink:NamedThing:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:CellularOrganism-biolink:subclass_of-biolink:OrganismalEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:ChemicalEntity-biolink:participates_in-biolink:Pathway:
+      count: 180
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 180
+    biolink:ChemicalEntity-biolink:related_to-biolink:ChemicalEntity:
+      count: 44
+      provided_by:
+        phenio_edges:
+          count: 44
+    biolink:ChemicalEntity-biolink:related_to-biolink:MolecularEntity:
+      count: 64
+      provided_by:
+        phenio_edges:
+          count: 64
+    biolink:ChemicalEntity-biolink:related_to-biolink:PhenotypicQuality:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:ChemicalEntity-biolink:subclass_of-biolink:ChemicalEntity:
+      count: 271
+      provided_by:
+        phenio_edges:
+          count: 271
+    biolink:ChemicalEntity-biolink:subclass_of-biolink:NamedThing:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:Disease-biolink:has_mode_of_inheritance-biolink:PhenotypicFeature:
+      count: 8411
+      provided_by:
+        hpoa_disease_mode_of_inheritance_edges:
+          count: 8411
+    biolink:Disease-biolink:has_phenotype-biolink:PhenotypicFeature:
+      count: 240262
+      provided_by:
+        hpoa_disease_to_phenotype_edges:
+          count: 240262
+    biolink:Disease-biolink:related_to-biolink:AnatomicalEntity:
+      count: 414
+      provided_by:
+        phenio_edges:
+          count: 414
+    biolink:Disease-biolink:related_to-biolink:BiologicalProcess:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:Disease-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 391
+      provided_by:
+        phenio_edges:
+          count: 391
+    biolink:Disease-biolink:related_to-biolink:Cell:
+      count: 127
+      provided_by:
+        phenio_edges:
+          count: 127
+    biolink:Disease-biolink:related_to-biolink:CellularComponent:
+      count: 22
+      provided_by:
+        phenio_edges:
+          count: 22
+    biolink:Disease-biolink:related_to-biolink:CellularOrganism:
+      count: 441
+      provided_by:
+        phenio_edges:
+          count: 441
+    biolink:Disease-biolink:related_to-biolink:ChemicalEntity:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:Disease-biolink:related_to-biolink:Disease:
+      count: 858
+      provided_by:
+        phenio_edges:
+          count: 858
+    biolink:Disease-biolink:related_to-biolink:DrugExposure:
+      count: 16
+      provided_by:
+        phenio_edges:
+          count: 16
+    biolink:Disease-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 2605
+      provided_by:
+        phenio_edges:
+          count: 2605
+    biolink:Disease-biolink:related_to-biolink:LifeStage:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:Disease-biolink:related_to-biolink:MacromolecularComplex:
+      count: 13
+      provided_by:
+        phenio_edges:
+          count: 13
+    biolink:Disease-biolink:related_to-biolink:MolecularEntity:
+      count: 42
+      provided_by:
+        phenio_edges:
+          count: 42
+    biolink:Disease-biolink:related_to-biolink:NamedThing:
+      count: 757
+      provided_by:
+        phenio_edges:
+          count: 757
+    biolink:Disease-biolink:related_to-biolink:OrganismalEntity:
+      count: 27
+      provided_by:
+        phenio_edges:
+          count: 27
+    biolink:Disease-biolink:related_to-biolink:Pathway:
+      count: 7
+      provided_by:
+        phenio_edges:
+          count: 7
+    biolink:Disease-biolink:related_to-biolink:PhenotypicFeature:
+      count: 1449
+      provided_by:
+        phenio_edges:
+          count: 1449
+    biolink:Disease-biolink:related_to-biolink:PhenotypicQuality:
+      count: 1584
+      provided_by:
+        phenio_edges:
+          count: 1584
+    biolink:Disease-biolink:related_to-biolink:Protein:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Disease-biolink:related_to-biolink:SmallMolecule:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:Disease-biolink:related_to-biolink:Vertebrate:
+      count: 61
+      provided_by:
+        phenio_edges:
+          count: 61
+    biolink:Disease-biolink:related_to-biolink:Virus:
+      count: 200
+      provided_by:
+        phenio_edges:
+          count: 200
+    biolink:Disease-biolink:subclass_of-biolink:Disease:
+      count: 38204
+      provided_by:
+        phenio_edges:
+          count: 38204
+    biolink:Disease-biolink:subclass_of-biolink:NamedThing:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:Drug-biolink:affects-biolink:Disease:
+      count: 20
+      provided_by:
+        ctd_chemical_to_disease_edges:
+          count: 20
+    biolink:Drug-biolink:participates_in-biolink:Pathway:
+      count: 10
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 10
+    biolink:Drug-biolink:subclass_of-biolink:Drug:
+      count: 100
+      provided_by:
+        phenio_edges:
+          count: 100
+    biolink:Drug-biolink:subclass_of-biolink:PhenotypicQuality:
+      count: 5
+      provided_by:
+        phenio_edges:
+          count: 5
+    biolink:EnvironmentalFeature-biolink:subclass_of-biolink:EnvironmentalFeature:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:EnvironmentalFeature-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:EvidenceType-biolink:related_to-biolink:EvidenceType:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:EvidenceType-biolink:related_to-biolink:InformationContentEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:EvidenceType-biolink:related_to-biolink:NamedThing:
+      count: 10
+      provided_by:
+        phenio_edges:
+          count: 10
+    biolink:EvidenceType-biolink:subclass_of-biolink:EvidenceType:
+      count: 23
+      provided_by:
+        phenio_edges:
+          count: 23
+    biolink:Gene-biolink:active_in-biolink:CellularComponent:
+      count: 142559
+      provided_by:
+        goa_go_annotation_edges:
+          count: 142559
+    biolink:Gene-biolink:actively_involved_in-biolink:BiologicalProcessOrActivity:
+      count: 746463
+      provided_by:
+        goa_go_annotation_edges:
+          count: 746463
+    biolink:Gene-biolink:actively_involved_in-biolink:Pathway:
+      count: 50641
+      provided_by:
+        goa_go_annotation_edges:
+          count: 50641
+    biolink:Gene-biolink:acts_upstream_of-biolink:BiologicalProcessOrActivity:
+      count: 8276
+      provided_by:
+        goa_go_annotation_edges:
+          count: 8276
+    biolink:Gene-biolink:acts_upstream_of-biolink:Pathway:
+      count: 1076
+      provided_by:
+        goa_go_annotation_edges:
+          count: 1076
+    biolink:Gene-biolink:acts_upstream_of_negative_effect-biolink:BiologicalProcessOrActivity:
+      count: 154
+      provided_by:
+        goa_go_annotation_edges:
+          count: 154
+    biolink:Gene-biolink:acts_upstream_of_negative_effect-biolink:Pathway:
+      count: 19
+      provided_by:
+        goa_go_annotation_edges:
+          count: 19
+    biolink:Gene-biolink:acts_upstream_of_or_within-biolink:BiologicalProcessOrActivity:
+      count: 167741
+      provided_by:
+        goa_go_annotation_edges:
+          count: 167741
+    biolink:Gene-biolink:acts_upstream_of_or_within-biolink:Pathway:
+      count: 12119
+      provided_by:
+        goa_go_annotation_edges:
+          count: 12119
+    biolink:Gene-biolink:acts_upstream_of_or_within_negative_effect-biolink:BiologicalProcessOrActivity:
+      count: 163
+      provided_by:
+        goa_go_annotation_edges:
+          count: 163
+    biolink:Gene-biolink:acts_upstream_of_or_within_negative_effect-biolink:Pathway:
+      count: 15
+      provided_by:
+        goa_go_annotation_edges:
+          count: 15
+    biolink:Gene-biolink:acts_upstream_of_or_within_positive_effect-biolink:BiologicalProcessOrActivity:
+      count: 457
+      provided_by:
+        goa_go_annotation_edges:
+          count: 457
+    biolink:Gene-biolink:acts_upstream_of_or_within_positive_effect-biolink:Pathway:
+      count: 47
+      provided_by:
+        goa_go_annotation_edges:
+          count: 47
+    biolink:Gene-biolink:acts_upstream_of_positive_effect-biolink:BiologicalProcessOrActivity:
+      count: 334
+      provided_by:
+        goa_go_annotation_edges:
+          count: 334
+    biolink:Gene-biolink:acts_upstream_of_positive_effect-biolink:Pathway:
+      count: 25
+      provided_by:
+        goa_go_annotation_edges:
+          count: 25
+    biolink:Gene-biolink:causes-biolink:Disease:
+      count: 6496
+      provided_by:
+        hpoa_gene_to_disease_edges:
+          count: 6496
+    biolink:Gene-biolink:colocalizes_with-biolink:CellularComponent:
+      count: 4046
+      provided_by:
+        goa_go_annotation_edges:
+          count: 4046
+    biolink:Gene-biolink:contributes_to-biolink:BiologicalProcessOrActivity:
+      count: 6853
+      provided_by:
+        goa_go_annotation_edges:
+          count: 6853
+    biolink:Gene-biolink:contributes_to-biolink:Disease:
+      count: 590
+      provided_by:
+        hpoa_gene_to_disease_edges:
+          count: 590
+    biolink:Gene-biolink:enables-biolink:BiologicalProcessOrActivity:
+      count: 838103
+      provided_by:
+        goa_go_annotation_edges:
+          count: 838103
+    biolink:Gene-biolink:expressed_in-biolink:AnatomicalEntity:
+      count: 398258
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 365333
+        bgee_gene_to_expression_edges:
+          count: 32925
+    biolink:Gene-biolink:expressed_in-biolink:Cell:
+      count: 131876
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 108787
+        bgee_gene_to_expression_edges:
+          count: 23089
+    biolink:Gene-biolink:expressed_in-biolink:CellularComponent:
+      count: 28670
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 28670
+    biolink:Gene-biolink:expressed_in-biolink:GrossAnatomicalStructure:
+      count: 1489641
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 1298526
+        bgee_gene_to_expression_edges:
+          count: 191115
+    biolink:Gene-biolink:expressed_in-biolink:MacromolecularComplex:
+      count: 6832
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 6832
+    biolink:Gene-biolink:expressed_in-biolink:NamedThing:
+      count: 40960
+      provided_by:
+        alliance_gene_to_expression_edges:
+          count: 40960
+    biolink:Gene-biolink:gene_associated_with_condition-biolink:Disease:
+      count: 7946
+      provided_by:
+        hpoa_gene_to_disease_edges:
+          count: 7946
+    biolink:Gene-biolink:has_mode_of_inheritance-biolink:PhenotypicFeature:
+      count: 5
+      provided_by:
+        hpoa_disease_mode_of_inheritance_edges:
+          count: 5
+    biolink:Gene-biolink:has_phenotype-biolink:PhenotypicFeature:
+      count: 882350
+      provided_by:
+        alliance_gene_to_phenotype_edges:
+          count: 300166
+        hpoa_disease_to_phenotype_edges:
+          count: 12
+        hpoa_gene_to_phenotype_edges:
+          count: 297505
+        pombase_gene_to_phenotype_edges:
+          count: 139030
+        xenbase_gene_to_phenotype_edges:
+          count: 2314
+        zfin_gene_to_phenotype_edges:
+          count: 143323
+    biolink:Gene-biolink:interacts_with-biolink:Gene:
+      count: 2760204
+      provided_by:
+        string_protein_links_edges:
+          count: 2760204
+    biolink:Gene-biolink:located_in-biolink:CellularComponent:
+      count: 498417
+      provided_by:
+        goa_go_annotation_edges:
+          count: 498417
+    biolink:Gene-biolink:located_in-biolink:MacromolecularComplex:
+      count: 38
+      provided_by:
+        goa_go_annotation_edges:
+          count: 38
+    biolink:Gene-biolink:orthologous_to-biolink:Gene:
+      count: 550848
+      provided_by:
+        panther_genome_orthologs_edges:
+          count: 550848
+    biolink:Gene-biolink:part_of-biolink:MacromolecularComplex:
+      count: 92927
+      provided_by:
+        goa_go_annotation_edges:
+          count: 92927
+    biolink:Gene-biolink:participates_in-biolink:Pathway:
+      count: 192345
+      provided_by:
+        reactome_gene_to_pathway_edges:
+          count: 192345
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:AnatomicalEntity:
+      count: 4478
+      provided_by:
+        phenio_edges:
+          count: 4478
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 341
+      provided_by:
+        phenio_edges:
+          count: 341
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:Cell:
+      count: 517
+      provided_by:
+        phenio_edges:
+          count: 517
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:CellularComponent:
+      count: 29
+      provided_by:
+        phenio_edges:
+          count: 29
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:CellularOrganism:
+      count: 565
+      provided_by:
+        phenio_edges:
+          count: 565
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 21067
+      provided_by:
+        phenio_edges:
+          count: 21067
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:MacromolecularComplex:
+      count: 6
+      provided_by:
+        phenio_edges:
+          count: 6
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:MolecularEntity:
+      count: 9
+      provided_by:
+        phenio_edges:
+          count: 9
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:NamedThing:
+      count: 10096
+      provided_by:
+        phenio_edges:
+          count: 10096
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:OrganismalEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:Protein:
+      count: 7
+      provided_by:
+        phenio_edges:
+          count: 7
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:SmallMolecule:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:GrossAnatomicalStructure-biolink:related_to-biolink:Vertebrate:
+      count: 12385
+      provided_by:
+        phenio_edges:
+          count: 12385
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:AnatomicalEntity:
+      count: 2699
+      provided_by:
+        phenio_edges:
+          count: 2699
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:Cell:
+      count: 107
+      provided_by:
+        phenio_edges:
+          count: 107
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:CellularComponent:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:GrossAnatomicalStructure:
+      count: 39070
+      provided_by:
+        phenio_edges:
+          count: 39070
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:NamedThing:
+      count: 126
+      provided_by:
+        phenio_edges:
+          count: 126
+    biolink:GrossAnatomicalStructure-biolink:subclass_of-biolink:Protein:
+      count: 110
+      provided_by:
+        phenio_edges:
+          count: 110
+    biolink:InformationContentEntity-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 10
+      provided_by:
+        phenio_edges:
+          count: 10
+    biolink:InformationContentEntity-biolink:related_to-biolink:InformationContentEntity:
+      count: 35
+      provided_by:
+        phenio_edges:
+          count: 35
+    biolink:InformationContentEntity-biolink:related_to-biolink:NamedThing:
+      count: 14
+      provided_by:
+        phenio_edges:
+          count: 14
+    biolink:InformationContentEntity-biolink:related_to-biolink:PopulationOfIndividualOrganisms:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:InformationContentEntity-biolink:subclass_of-biolink:EvidenceType:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:InformationContentEntity-biolink:subclass_of-biolink:InformationContentEntity:
+      count: 83
+      provided_by:
+        phenio_edges:
+          count: 83
+    biolink:InformationContentEntity-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:LifeStage-biolink:related_to-biolink:LifeStage:
+      count: 460
+      provided_by:
+        phenio_edges:
+          count: 460
+    biolink:LifeStage-biolink:subclass_of-biolink:LifeStage:
+      count: 237
+      provided_by:
+        phenio_edges:
+          count: 237
+    biolink:MacromolecularComplex-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 81
+      provided_by:
+        phenio_edges:
+          count: 81
+    biolink:MacromolecularComplex-biolink:related_to-biolink:CellularComponent:
+      count: 582
+      provided_by:
+        phenio_edges:
+          count: 582
+    biolink:MacromolecularComplex-biolink:related_to-biolink:CellularOrganism:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:MacromolecularComplex-biolink:related_to-biolink:MacromolecularComplex:
+      count: 274
+      provided_by:
+        phenio_edges:
+          count: 274
+    biolink:MacromolecularComplex-biolink:related_to-biolink:MolecularEntity:
+      count: 5
+      provided_by:
+        phenio_edges:
+          count: 5
+    biolink:MacromolecularComplex-biolink:related_to-biolink:Pathway:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:MacromolecularComplex-biolink:related_to-biolink:Protein:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:MacromolecularComplex-biolink:related_to-biolink:RNAProduct:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:MacromolecularComplex-biolink:related_to-biolink:Vertebrate:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:MacromolecularComplex-biolink:subclass_of-biolink:CellularComponent:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:MacromolecularComplex-biolink:subclass_of-biolink:MacromolecularComplex:
+      count: 2655
+      provided_by:
+        phenio_edges:
+          count: 2655
+    biolink:MacromolecularComplex-biolink:subclass_of-biolink:Protein:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:MolecularEntity-biolink:affects-biolink:Disease:
+      count: 249
+      provided_by:
+        ctd_chemical_to_disease_edges:
+          count: 249
+    biolink:MolecularEntity-biolink:participates_in-biolink:Pathway:
+      count: 62367
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 62367
+    biolink:MolecularEntity-biolink:related_to-biolink:ChemicalEntity:
+      count: 109
+      provided_by:
+        phenio_edges:
+          count: 109
+    biolink:MolecularEntity-biolink:related_to-biolink:Drug:
+      count: 442
+      provided_by:
+        phenio_edges:
+          count: 442
+    biolink:MolecularEntity-biolink:related_to-biolink:MolecularEntity:
+      count: 2991
+      provided_by:
+        phenio_edges:
+          count: 2991
+    biolink:MolecularEntity-biolink:related_to-biolink:PhenotypicQuality:
+      count: 94
+      provided_by:
+        phenio_edges:
+          count: 94
+    biolink:MolecularEntity-biolink:related_to-biolink:SmallMolecule:
+      count: 7
+      provided_by:
+        phenio_edges:
+          count: 7
+    biolink:MolecularEntity-biolink:subclass_of-biolink:ChemicalEntity:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:MolecularEntity-biolink:subclass_of-biolink:MolecularEntity:
+      count: 7445
+      provided_by:
+        phenio_edges:
+          count: 7445
+    biolink:MolecularEntity-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:NamedThing-biolink:related_to-biolink:AnatomicalEntity:
+      count: 381
+      provided_by:
+        phenio_edges:
+          count: 381
+    biolink:NamedThing-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:NamedThing-biolink:related_to-biolink:Cell:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:NamedThing-biolink:related_to-biolink:CellularOrganism:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:NamedThing-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 1606
+      provided_by:
+        phenio_edges:
+          count: 1606
+    biolink:NamedThing-biolink:related_to-biolink:InformationContentEntity:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:NamedThing-biolink:related_to-biolink:NamedThing:
+      count: 4000
+      provided_by:
+        phenio_edges:
+          count: 4000
+    biolink:NamedThing-biolink:related_to-biolink:Plant:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:NamedThing-biolink:related_to-biolink:Protein:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:NamedThing-biolink:related_to-biolink:Vertebrate:
+      count: 14
+      provided_by:
+        phenio_edges:
+          count: 14
+    biolink:NamedThing-biolink:subclass_of-biolink:Cell:
+      count: 15
+      provided_by:
+        phenio_edges:
+          count: 15
+    biolink:NamedThing-biolink:subclass_of-biolink:NamedThing:
+      count: 2952
+      provided_by:
+        phenio_edges:
+          count: 2952
+    biolink:NamedThing-biolink:subclass_of-biolink:PhenotypicQuality:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:NucleicAcidEntity-biolink:related_to-biolink:MolecularEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:NucleicAcidEntity-biolink:related_to-biolink:NucleicAcidEntity:
+      count: 5
+      provided_by:
+        phenio_edges:
+          count: 5
+    biolink:NucleicAcidEntity-biolink:related_to-biolink:Polypeptide:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:NucleicAcidEntity-biolink:related_to-biolink:RNAProduct:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:NucleicAcidEntity-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:NucleicAcidEntity-biolink:subclass_of-biolink:NucleicAcidEntity:
+      count: 18
+      provided_by:
+        phenio_edges:
+          count: 18
+    biolink:OrganismalEntity-biolink:subclass_of-biolink:NamedThing:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:PathologicalProcess-biolink:subclass_of-biolink:PathologicalProcess:
+      count: 236
+      provided_by:
+        phenio_edges:
+          count: 236
+    biolink:Pathway-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 318
+      provided_by:
+        phenio_edges:
+          count: 318
+    biolink:Pathway-biolink:related_to-biolink:CellularComponent:
+      count: 6
+      provided_by:
+        phenio_edges:
+          count: 6
+    biolink:Pathway-biolink:related_to-biolink:CellularOrganism:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Pathway-biolink:related_to-biolink:MolecularEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Pathway-biolink:related_to-biolink:Pathway:
+      count: 11
+      provided_by:
+        phenio_edges:
+          count: 11
+    biolink:Pathway-biolink:related_to-biolink:Protein:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Pathway-biolink:subclass_of-biolink:BiologicalProcessOrActivity:
+      count: 128
+      provided_by:
+        phenio_edges:
+          count: 128
+    biolink:Pathway-biolink:subclass_of-biolink:Pathway:
+      count: 837
+      provided_by:
+        phenio_edges:
+          count: 837
+    biolink:PhenotypicFeature-biolink:related_to-biolink:AnatomicalEntity:
+      count: 2594
+      provided_by:
+        phenio_edges:
+          count: 2594
+    biolink:PhenotypicFeature-biolink:related_to-biolink:BehavioralFeature:
+      count: 22
+      provided_by:
+        phenio_edges:
+          count: 22
+    biolink:PhenotypicFeature-biolink:related_to-biolink:BiologicalProcess:
+      count: 138
+      provided_by:
+        phenio_edges:
+          count: 138
+    biolink:PhenotypicFeature-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 6725
+      provided_by:
+        phenio_edges:
+          count: 6725
+    biolink:PhenotypicFeature-biolink:related_to-biolink:Cell:
+      count: 775
+      provided_by:
+        phenio_edges:
+          count: 775
+    biolink:PhenotypicFeature-biolink:related_to-biolink:CellularComponent:
+      count: 2603
+      provided_by:
+        phenio_edges:
+          count: 2603
+    biolink:PhenotypicFeature-biolink:related_to-biolink:ChemicalEntity:
+      count: 68
+      provided_by:
+        phenio_edges:
+          count: 68
+    biolink:PhenotypicFeature-biolink:related_to-biolink:GrossAnatomicalStructure:
+      count: 7570
+      provided_by:
+        phenio_edges:
+          count: 7570
+    biolink:PhenotypicFeature-biolink:related_to-biolink:MacromolecularComplex:
+      count: 290
+      provided_by:
+        phenio_edges:
+          count: 290
+    biolink:PhenotypicFeature-biolink:related_to-biolink:MolecularActivity:
+      count: 6
+      provided_by:
+        phenio_edges:
+          count: 6
+    biolink:PhenotypicFeature-biolink:related_to-biolink:MolecularEntity:
+      count: 864
+      provided_by:
+        phenio_edges:
+          count: 864
+    biolink:PhenotypicFeature-biolink:related_to-biolink:NamedThing:
+      count: 20326
+      provided_by:
+        phenio_edges:
+          count: 20326
+    biolink:PhenotypicFeature-biolink:related_to-biolink:PathologicalProcess:
+      count: 60
+      provided_by:
+        phenio_edges:
+          count: 60
+    biolink:PhenotypicFeature-biolink:related_to-biolink:Pathway:
+      count: 155
+      provided_by:
+        phenio_edges:
+          count: 155
+    biolink:PhenotypicFeature-biolink:related_to-biolink:PhenotypicFeature:
+      count: 318
+      provided_by:
+        phenio_edges:
+          count: 318
+    biolink:PhenotypicFeature-biolink:related_to-biolink:Protein:
+      count: 137
+      provided_by:
+        phenio_edges:
+          count: 137
+    biolink:PhenotypicFeature-biolink:related_to-biolink:RNAProduct:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:PhenotypicFeature-biolink:related_to-biolink:SmallMolecule:
+      count: 22
+      provided_by:
+        phenio_edges:
+          count: 22
+    biolink:PhenotypicFeature-biolink:related_to-biolink:Transcript:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:PhenotypicFeature-biolink:subclass_of-biolink:NamedThing:
+      count: 335
+      provided_by:
+        phenio_edges:
+          count: 335
+    biolink:PhenotypicFeature-biolink:subclass_of-biolink:PhenotypicFeature:
+      count: 227331
+      provided_by:
+        phenio_edges:
+          count: 227331
+    biolink:PhenotypicQuality-biolink:related_to-biolink:PhenotypicQuality:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:PhenotypicQuality-biolink:subclass_of-biolink:NamedThing:
+      count: 4
+      provided_by:
+        phenio_edges:
+          count: 4
+    biolink:PhenotypicQuality-biolink:subclass_of-biolink:PhenotypicQuality:
+      count: 86
+      provided_by:
+        phenio_edges:
+          count: 86
+    biolink:Plant-biolink:subclass_of-biolink:NamedThing:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:Plant-biolink:subclass_of-biolink:Plant:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Polypeptide-biolink:related_to-biolink:RNAProduct:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Polypeptide-biolink:subclass_of-biolink:NucleicAcidEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:PopulationOfIndividualOrganisms-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:PopulationOfIndividualOrganisms-biolink:subclass_of-biolink:PopulationOfIndividualOrganisms:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Protein-biolink:acts_upstream_of_or_within-biolink:BiologicalProcessOrActivity:
+      count: 2
+      provided_by:
+        goa_go_annotation_edges:
+          count: 2
+    biolink:Protein-biolink:enables-biolink:BiologicalProcessOrActivity:
+      count: 1
+      provided_by:
+        goa_go_annotation_edges:
+          count: 1
+    biolink:Protein-biolink:located_in-biolink:CellularComponent:
+      count: 6
+      provided_by:
+        goa_go_annotation_edges:
+          count: 6
+    biolink:Protein-biolink:participates_in-biolink:Pathway:
+      count: 605
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 605
+    biolink:Protein-biolink:related_to-biolink:BiologicalProcessOrActivity:
+      count: 60
+      provided_by:
+        phenio_edges:
+          count: 60
+    biolink:Protein-biolink:related_to-biolink:CellularOrganism:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:Protein-biolink:related_to-biolink:MolecularEntity:
+      count: 6
+      provided_by:
+        phenio_edges:
+          count: 6
+    biolink:Protein-biolink:related_to-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Protein-biolink:related_to-biolink:NucleicAcidEntity:
+      count: 191
+      provided_by:
+        phenio_edges:
+          count: 191
+    biolink:Protein-biolink:related_to-biolink:Pathway:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Protein-biolink:related_to-biolink:Protein:
+      count: 5
+      provided_by:
+        phenio_edges:
+          count: 5
+    biolink:Protein-biolink:related_to-biolink:Vertebrate:
+      count: 457
+      provided_by:
+        phenio_edges:
+          count: 457
+    biolink:Protein-biolink:subclass_of-biolink:MolecularEntity:
+      count: 6
+      provided_by:
+        phenio_edges:
+          count: 6
+    biolink:Protein-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Protein-biolink:subclass_of-biolink:Protein:
+      count: 1833
+      provided_by:
+        phenio_edges:
+          count: 1833
+    biolink:RNAProduct-biolink:participates_in-biolink:Pathway:
+      count: 642
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 642
+    biolink:RNAProduct-biolink:related_to-biolink:ChemicalEntity:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:RNAProduct-biolink:related_to-biolink:RNAProduct:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:RNAProduct-biolink:related_to-biolink:Transcript:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:RNAProduct-biolink:subclass_of-biolink:MolecularEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:RNAProduct-biolink:subclass_of-biolink:NucleicAcidEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:RNAProduct-biolink:subclass_of-biolink:RNAProduct:
+      count: 13
+      provided_by:
+        phenio_edges:
+          count: 13
+    biolink:SmallMolecule-biolink:affects-biolink:Disease:
+      count: 7
+      provided_by:
+        ctd_chemical_to_disease_edges:
+          count: 7
+    biolink:SmallMolecule-biolink:participates_in-biolink:Pathway:
+      count: 46
+      provided_by:
+        reactome_chemical_to_pathway_edges:
+          count: 46
+    biolink:SmallMolecule-biolink:related_to-biolink:Drug:
+      count: 18
+      provided_by:
+        phenio_edges:
+          count: 18
+    biolink:SmallMolecule-biolink:related_to-biolink:MolecularEntity:
+      count: 103
+      provided_by:
+        phenio_edges:
+          count: 103
+    biolink:SmallMolecule-biolink:related_to-biolink:PhenotypicQuality:
+      count: 5
+      provided_by:
+        phenio_edges:
+          count: 5
+    biolink:SmallMolecule-biolink:related_to-biolink:SmallMolecule:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:SmallMolecule-biolink:subclass_of-biolink:ChemicalEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:SmallMolecule-biolink:subclass_of-biolink:MolecularEntity:
+      count: 60
+      provided_by:
+        phenio_edges:
+          count: 60
+    biolink:SmallMolecule-biolink:subclass_of-biolink:SmallMolecule:
+      count: 68
+      provided_by:
+        phenio_edges:
+          count: 68
+    biolink:Transcript-biolink:related_to-biolink:NucleicAcidEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Transcript-biolink:related_to-biolink:Transcript:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Transcript-biolink:subclass_of-biolink:NucleicAcidEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Transcript-biolink:subclass_of-biolink:RNAProduct:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Transcript-biolink:subclass_of-biolink:Transcript:
+      count: 3
+      provided_by:
+        phenio_edges:
+          count: 3
+    biolink:Vertebrate-biolink:subclass_of-biolink:CellularOrganism:
+      count: 2
+      provided_by:
+        phenio_edges:
+          count: 2
+    biolink:Vertebrate-biolink:subclass_of-biolink:Vertebrate:
+      count: 391
+      provided_by:
+        phenio_edges:
+          count: 391
+    biolink:Virus-biolink:subclass_of-biolink:NamedThing:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Virus-biolink:subclass_of-biolink:OrganismalEntity:
+      count: 1
+      provided_by:
+        phenio_edges:
+          count: 1
+    biolink:Virus-biolink:subclass_of-biolink:Virus:
+      count: 307
+      provided_by:
+        phenio_edges:
+          count: 307
+  predicates:
+  - biolink:active_in
+  - biolink:actively_involved_in
+  - biolink:acts_upstream_of
+  - biolink:acts_upstream_of_negative_effect
+  - biolink:acts_upstream_of_or_within
+  - biolink:acts_upstream_of_or_within_negative_effect
+  - biolink:acts_upstream_of_or_within_positive_effect
+  - biolink:acts_upstream_of_positive_effect
+  - biolink:affects
+  - biolink:causes
+  - biolink:colocalizes_with
+  - biolink:contributes_to
+  - biolink:enables
+  - biolink:expressed_in
+  - biolink:gene_associated_with_condition
+  - biolink:has_mode_of_inheritance
+  - biolink:has_phenotype
+  - biolink:interacts_with
+  - biolink:located_in
+  - biolink:orthologous_to
+  - biolink:part_of
+  - biolink:participates_in
+  - biolink:related_to
+  - biolink:subclass_of
+  provided_by:
+  - alliance_gene_to_expression_edges
+  - alliance_gene_to_phenotype_edges
+  - bgee_gene_to_expression_edges
+  - ctd_chemical_to_disease_edges
+  - goa_go_annotation_edges
+  - hpoa_disease_mode_of_inheritance_edges
+  - hpoa_disease_to_phenotype_edges
+  - hpoa_gene_to_disease_edges
+  - hpoa_gene_to_phenotype_edges
+  - panther_genome_orthologs_edges
+  - phenio_edges
+  - pombase_gene_to_phenotype_edges
+  - reactome_chemical_to_pathway_edges
+  - reactome_gene_to_pathway_edges
+  - string_protein_links_edges
+  - xenbase_gene_to_phenotype_edges
+  - zfin_gene_to_phenotype_edges
+  total_edges: 10049896
+graph_name: Graph
+node_stats:
+  count_by_category:
+    biolink:AccessibleDnaRegion:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Activity:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:Agent:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:AnatomicalEntity:
+      count: 12283
+      provided_by:
+        phenio_nodes:
+          count: 12283
+    biolink:Article:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Attribute:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Bacterium:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:BehavioralFeature:
+      count: 297
+      provided_by:
+        phenio_nodes:
+          count: 297
+    biolink:BiologicalEntity:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:BiologicalProcess:
+      count: 2990
+      provided_by:
+        phenio_nodes:
+          count: 2990
+    biolink:BiologicalProcessOrActivity:
+      count: 38898
+      provided_by:
+        phenio_nodes:
+          count: 38898
+    biolink:BiologicalSex:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Cell:
+      count: 17928
+      provided_by:
+        phenio_nodes:
+          count: 17928
+    biolink:CellLine:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:CellularComponent:
+      count: 5273
+      provided_by:
+        phenio_nodes:
+          count: 5273
+    biolink:CellularOrganism:
+      count: 963
+      provided_by:
+        phenio_nodes:
+          count: 963
+    biolink:ChemicalEntity:
+      count: 209
+      provided_by:
+        phenio_nodes:
+          count: 209
+    biolink:ChemicalExposure:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:ChemicalMixture:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:CodingSequence:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:ConfidenceLevel:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:Dataset:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:DatasetDistribution:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:DiagnosticAid:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Disease:
+      count: 26553
+      provided_by:
+        phenio_nodes:
+          count: 26553
+    biolink:Drug:
+      count: 99
+      provided_by:
+        phenio_nodes:
+          count: 99
+    biolink:DrugExposure:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:EnvironmentalFeature:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:EnvironmentalProcess:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Event:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:EvidenceType:
+      count: 16
+      provided_by:
+        phenio_nodes:
+          count: 16
+    biolink:Exon:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:Fungus:
+      count: 4
+      provided_by:
+        phenio_nodes:
+          count: 4
+    biolink:Gene:
+      count: 559216
+      provided_by:
+        alliance_gene_nodes:
+          count: 299774
+        dictybase_gene_nodes:
+          count: 14222
+        hgnc_gene_nodes:
+          count: 43736
+        ncbi_gene_nodes:
+          count: 196348
+        phenio_nodes:
+          count: 2
+        pombase_gene_nodes:
+          count: 5134
+    biolink:GeneticInheritance:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:Genome:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:Genotype:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:GenotypicSex:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:GeographicExposure:
+      count: 14
+      provided_by:
+        phenio_nodes:
+          count: 14
+    biolink:GrossAnatomicalStructure:
+      count: 28521
+      provided_by:
+        phenio_nodes:
+          count: 28521
+    biolink:Haplotype:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:Human:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:IndividualOrganism:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:InformationContentEntity:
+      count: 75
+      provided_by:
+        phenio_nodes:
+          count: 75
+    biolink:Invertebrate:
+      count: 3
+      provided_by:
+        phenio_nodes:
+          count: 3
+    biolink:LifeStage:
+      count: 238
+      provided_by:
+        phenio_nodes:
+          count: 238
+    biolink:MacromolecularComplex:
+      count: 2130
+      provided_by:
+        phenio_nodes:
+          count: 2130
+    biolink:Mammal:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:MaterialSample:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:MicroRNA:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:MolecularActivity:
+      count: 1280
+      provided_by:
+        phenio_nodes:
+          count: 1280
+    biolink:MolecularEntity:
+      count: 4470
+      provided_by:
+        phenio_nodes:
+          count: 4470
+    biolink:NamedThing:
+      count: 18332
+      provided_by:
+        phenio_nodes:
+          count: 18332
+    biolink:NoncodingRNAProduct:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:NucleicAcidEntity:
+      count: 19
+      provided_by:
+        phenio_nodes:
+          count: 19
+    biolink:OrganismTaxon:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:OrganismalEntity:
+      count: 31
+      provided_by:
+        phenio_nodes:
+          count: 31
+    biolink:Patent:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:PathologicalProcess:
+      count: 231
+      provided_by:
+        phenio_nodes:
+          count: 231
+    biolink:Pathway:
+      count: 22283
+      provided_by:
+        phenio_nodes:
+          count: 679
+        reactome_pathway_nodes:
+          count: 21604
+    biolink:PhenotypicFeature:
+      count: 117139
+      provided_by:
+        phenio_nodes:
+          count: 117139
+    biolink:PhenotypicQuality:
+      count: 86
+      provided_by:
+        phenio_nodes:
+          count: 86
+    biolink:PhenotypicSex:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Plant:
+      count: 4
+      provided_by:
+        phenio_nodes:
+          count: 4
+    biolink:Polypeptide:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:PopulationOfIndividualOrganisms:
+      count: 4
+      provided_by:
+        phenio_nodes:
+          count: 4
+    biolink:Procedure:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:ProcessedMaterial:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Protein:
+      count: 1081
+      provided_by:
+        phenio_nodes:
+          count: 1081
+    biolink:ProteinDomain:
+      count: 3
+      provided_by:
+        phenio_nodes:
+          count: 3
+    biolink:ProteinFamily:
+      count: 3
+      provided_by:
+        phenio_nodes:
+          count: 3
+    biolink:Publication:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:RNAProduct:
+      count: 12
+      provided_by:
+        phenio_nodes:
+          count: 12
+    biolink:ReagentTargetedGene:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:RegulatoryRegion:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:SiRNA:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:SmallMolecule:
+      count: 68
+      provided_by:
+        phenio_nodes:
+          count: 68
+    biolink:Snv:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Study:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:StudyVariable:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Transcript:
+      count: 6
+      provided_by:
+        phenio_nodes:
+          count: 6
+    biolink:TranscriptionFactorBindingSite:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    biolink:Treatment:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:Vertebrate:
+      count: 389
+      provided_by:
+        phenio_nodes:
+          count: 389
+    biolink:Virus:
+      count: 308
+      provided_by:
+        phenio_nodes:
+          count: 308
+    biolink:WebPage:
+      count: 2
+      provided_by:
+        phenio_nodes:
+          count: 2
+    biolink:Zygosity:
+      count: 1
+      provided_by:
+        phenio_nodes:
+          count: 1
+    unknown:
+      count: 0
+  count_by_id_prefixes:
+    APO: 1
+    BFO: 39
+    BSPO: 79
+    BTO: 1
+    CARO: 5
+    CHEBI: 4912
+    CHR: 203
+    CIO: 1
+    CL: 1685
+    CLO: 1
+    DATACOMMONS: 22
+    DOAP: 3
+    DOID: 1
+    ECO: 35
+    ECTO: 17
+    EMAPA: 8752
+    ENVO: 22
+    FAO: 115
+    FB: 30284
+    FBbt: 19980
+    FBcv: 1
+    FMA: 6511
+    FOODON: 4
+    FYPO: 7967
+    GENO: 5
+    GO: 51241
+    GOREL: 2
+    HGNC: 43736
+    HP: 16974
+    HSAPDV: 259
+    IAO: 99
+    LINKML: 9
+    MA: 3072
+    MAXO: 2
+    MESH: 2
+    MF: 4
+    MFOMD: 6
+    MGI: 79680
+    MOD: 1
+    MONDO: 26585
+    MP: 14049
+    MPATH: 280
+    NBO: 934
+    NCBIGene: 196348
+    NCBITaxon: 1691
+    NCIT: 41
+    NIF.EXT: 3
+    NIF.STD: 1
+    NLX.OEN: 1
+    NLX.SUB: 1
+    OBA: 5181
+    OBI: 43
+    OBO: 79
+    OGMS: 2
+    OIO: 10
+    OMIT: 2
+    OMO: 13
+    Orphanet: 1
+    PATO: 633
+    PCO: 1
+    PHENIO: 1
+    PO: 67
+    PR: 1063
+    PROV: 2
+    PW: 1
+    PomBase: 5134
+    REACT: 21604
+    RGD: 57146
+    RNORDV: 1
+    RO: 530
+    SEPIO: 1
+    SGD: 7153
+    SIO: 32
+    SNOMED: 1
+    SNOMEDCT: 1
+    SO: 41
+    STATO: 42
+    TO: 1
+    TS: 28
+    UBERON: 15830
+    UBPROP: 31
+    UMLS: 3
+    UPHENO: 19632
+    WB: 48779
+    WBLS: 1
+    WBPhenotype: 2695
+    WBbt: 7556
+    XAO: 1605
+    XPO: 20061
+    Xenbase: 38732
+    ZFA: 3218
+    ZFIN: 38000
+    ZFS: 38
+    ZP: 36602
+    dc: 9
+    dcat: 1
+    dcterms: 3
+    dctypes: 1
+    dictyBase: 14222
+    foaf: 4
+    owl: 3
+    rdfs: 3
+  count_by_id_prefixes_by_category:
+    biolink:AccessibleDnaRegion:
+      SO: 1
+    biolink:Activity:
+      NCIT: 1
+      PROV: 1
+    biolink:Agent:
+      PROV: 1
+      dcterms: 1
+    biolink:AnatomicalEntity:
+      CARO: 1
+      EMAPA: 1119
+      FBbt: 2294
+      FMA: 1774
+      MA: 613
+      NCIT: 1
+      NIF.EXT: 1
+      NIF.STD: 1
+      SIO: 1
+      UBERON: 5438
+      WBbt: 141
+      XAO: 1
+      ZFA: 898
+    biolink:Article:
+      SIO: 1
+    biolink:Attribute:
+      SIO: 1
+    biolink:Bacterium:
+      NCBITaxon: 1
+    biolink:BehavioralFeature:
+      NBO: 297
+    biolink:BiologicalEntity:
+      SIO: 1
+    biolink:BiologicalProcess:
+      GO: 2989
+      SIO: 1
+    biolink:BiologicalProcessOrActivity:
+      BFO: 9
+      FMA: 3
+      GO: 38163
+      IAO: 1
+      NBO: 635
+      OBI: 10
+      PO: 7
+      RO: 1
+      STATO: 9
+      UBERON: 60
+    biolink:BiologicalSex:
+      PATO: 1
+    biolink:Cell:
+      CL: 1679
+      EMAPA: 5
+      FBbt: 12380
+      FMA: 470
+      GO: 1
+      MA: 3
+      SIO: 1
+      WBbt: 3388
+      ZFA: 1
+    biolink:CellLine:
+      CLO: 1
+    biolink:CellularComponent:
+      CL: 5
+      GO: 2359
+      SIO: 1
+      WBbt: 2908
+    biolink:CellularOrganism:
+      NCBITaxon: 963
+    biolink:ChemicalEntity:
+      CHEBI: 208
+      SIO: 1
+    biolink:ChemicalExposure:
+      ECTO: 1
+      SIO: 1
+    biolink:ChemicalMixture:
+      NCIT: 1
+    biolink:CodingSequence:
+      SIO: 1
+    biolink:ConfidenceLevel:
+      CIO: 1
+      SEPIO: 1
+    biolink:Dataset:
+      DATACOMMONS: 1
+      dctypes: 1
+    biolink:DatasetDistribution:
+      dcat: 1
+    biolink:DiagnosticAid:
+      SNOMED: 1
+    biolink:Disease:
+      DATACOMMONS: 1
+      DOID: 1
+      MESH: 2
+      MONDO: 26544
+      NCIT: 1
+      Orphanet: 1
+      SIO: 1
+      SNOMEDCT: 1
+      UMLS: 1
+    biolink:Drug:
+      CHEBI: 98
+      DATACOMMONS: 1
+    biolink:DrugExposure:
+      ECTO: 1
+    biolink:EnvironmentalFeature:
+      ENVO: 2
+    biolink:EnvironmentalProcess:
+      ENVO: 1
+    biolink:Event:
+      NCIT: 1
+    biolink:EvidenceType:
+      ECO: 16
+    biolink:Exon:
+      SIO: 1
+      SO: 1
+    biolink:Fungus:
+      FOODON: 2
+      NCBITaxon: 1
+      NCIT: 1
+    biolink:Gene:
+      DATACOMMONS: 1
+      FB: 30284
+      HGNC: 43736
+      MGI: 79680
+      NCBIGene: 196348
+      PomBase: 5134
+      RGD: 57146
+      SGD: 7153
+      SIO: 1
+      WB: 48779
+      Xenbase: 38732
+      ZFIN: 38000
+      dictyBase: 14222
+    biolink:GeneticInheritance:
+      GENO: 1
+      NCIT: 1
+    biolink:Genome:
+      SIO: 1
+      SO: 1
+    biolink:Genotype:
+      GENO: 1
+      SIO: 1
+    biolink:GenotypicSex:
+      PATO: 1
+    biolink:GeographicExposure:
+      DATACOMMONS: 14
+    biolink:GrossAnatomicalStructure:
+      EMAPA: 4751
+      FBbt: 4195
+      FMA: 4256
+      MA: 2456
+      NIF.EXT: 2
+      NLX.OEN: 1
+      NLX.SUB: 1
+      UBERON: 10332
+      WBbt: 326
+      ZFA: 2201
+    biolink:Haplotype:
+      GENO: 1
+      SO: 1
+    biolink:Human:
+      NCIT: 1
+      SIO: 1
+    biolink:IndividualOrganism:
+      SIO: 1
+      foaf: 1
+    biolink:InformationContentEntity:
+      ECO: 15
+      IAO: 22
+      OBI: 14
+      OBO: 1
+      STATO: 23
+    biolink:Invertebrate:
+      FOODON: 1
+      NCIT: 1
+      OMIT: 1
+    biolink:LifeStage:
+      HSAPDV: 238
+    biolink:MacromolecularComplex:
+      CL: 1
+      GO: 2126
+      PR: 3
+    biolink:Mammal:
+      FOODON: 1
+      NCIT: 1
+    biolink:MaterialSample:
+      OBI: 1
+      SIO: 1
+    biolink:MicroRNA:
+      SIO: 1
+      SO: 1
+    biolink:MolecularActivity:
+      GO: 1280
+    biolink:MolecularEntity:
+      CHEBI: 4469
+      PR: 1
+    biolink:NamedThing:
+      BFO: 30
+      BSPO: 79
+      BTO: 1
+      CARO: 3
+      CHR: 203
+      DATACOMMONS: 1
+      DOAP: 3
+      ECO: 4
+      ECTO: 15
+      EMAPA: 2877
+      ENVO: 19
+      FAO: 115
+      FBbt: 1111
+      FMA: 8
+      FYPO: 321
+      GO: 3646
+      GOREL: 2
+      HSAPDV: 21
+      IAO: 73
+      LINKML: 9
+      MAXO: 2
+      MF: 4
+      MFOMD: 6
+      MOD: 1
+      MP: 444
+      MPATH: 52
+      NBO: 2
+      NCIT: 21
+      OBA: 5181
+      OBI: 14
+      OBO: 77
+      OGMS: 1
+      OIO: 10
+      OMO: 13
+      PATO: 630
+      PHENIO: 1
+      PO: 58
+      RNORDV: 1
+      RO: 529
+      STATO: 9
+      TS: 28
+      UBPROP: 31
+      UPHENO: 20
+      WBLS: 1
+      WBPhenotype: 62
+      WBbt: 793
+      XAO: 1604
+      ZFA: 118
+      ZFS: 38
+      dc: 9
+      dcterms: 2
+      foaf: 3
+      owl: 3
+      rdfs: 3
+    biolink:NoncodingRNAProduct:
+      SIO: 1
+    biolink:NucleicAcidEntity:
+      OBI: 1
+      SO: 18
+    biolink:OrganismTaxon:
+      DATACOMMONS: 1
+    biolink:OrganismalEntity:
+      CARO: 1
+      NCBITaxon: 30
+    biolink:Patent:
+      IAO: 1
+      SIO: 1
+    biolink:PathologicalProcess:
+      MPATH: 228
+      NCIT: 2
+      OBI: 1
+    biolink:Pathway:
+      GO: 677
+      PW: 1
+      REACT: 21604
+      SIO: 1
+    biolink:PhenotypicFeature:
+      APO: 1
+      FBcv: 1
+      FYPO: 7646
+      HP: 16974
+      MP: 13605
+      NCIT: 1
+      SIO: 1
+      TO: 1
+      UMLS: 1
+      UPHENO: 19612
+      WBPhenotype: 2633
+      XPO: 20061
+      ZP: 36602
+    biolink:PhenotypicQuality:
+      CHEBI: 45
+      MONDO: 41
+    biolink:PhenotypicSex:
+      PATO: 1
+    biolink:Plant:
+      NCIT: 2
+      PO: 2
+    biolink:Polypeptide:
+      SO: 1
+    biolink:PopulationOfIndividualOrganisms:
+      OBI: 1
+      PCO: 1
+      SIO: 1
+      STATO: 1
+    biolink:Procedure:
+      DATACOMMONS: 1
+    biolink:ProcessedMaterial:
+      OBI: 1
+    biolink:Protein:
+      CHEBI: 21
+      PR: 1059
+      SIO: 1
+    biolink:ProteinDomain:
+      NCIT: 1
+      SIO: 1
+      UMLS: 1
+    biolink:ProteinFamily:
+      NCIT: 2
+      SIO: 1
+    biolink:Publication:
+      IAO: 2
+    biolink:RNAProduct:
+      CHEBI: 3
+      SO: 9
+    biolink:ReagentTargetedGene:
+      GENO: 1
+    biolink:RegulatoryRegion:
+      SIO: 1
+      SO: 1
+    biolink:SiRNA:
+      SO: 1
+    biolink:SmallMolecule:
+      CHEBI: 68
+    biolink:Snv:
+      SO: 1
+    biolink:Study:
+      NCIT: 1
+      SIO: 1
+    biolink:StudyVariable:
+      NCIT: 1
+    biolink:Transcript:
+      DATACOMMONS: 1
+      SIO: 1
+      SO: 4
+    biolink:TranscriptionFactorBindingSite:
+      SO: 1
+    biolink:Treatment:
+      OGMS: 1
+      SIO: 1
+    biolink:Vertebrate:
+      NCBITaxon: 388
+      OMIT: 1
+    biolink:Virus:
+      NCBITaxon: 308
+    biolink:WebPage:
+      OBO: 1
+      SIO: 1
+    biolink:Zygosity:
+      GENO: 1
+    unknown: {}
+  node_categories:
+  - biolink:AccessibleDnaRegion
+  - biolink:Activity
+  - biolink:Agent
+  - biolink:AnatomicalEntity
+  - biolink:Article
+  - biolink:Attribute
+  - biolink:Bacterium
+  - biolink:BehavioralFeature
+  - biolink:BiologicalEntity
+  - biolink:BiologicalProcess
+  - biolink:BiologicalProcessOrActivity
+  - biolink:BiologicalSex
+  - biolink:Cell
+  - biolink:CellLine
+  - biolink:CellularComponent
+  - biolink:CellularOrganism
+  - biolink:ChemicalEntity
+  - biolink:ChemicalExposure
+  - biolink:ChemicalMixture
+  - biolink:CodingSequence
+  - biolink:ConfidenceLevel
+  - biolink:Dataset
+  - biolink:DatasetDistribution
+  - biolink:DiagnosticAid
+  - biolink:Disease
+  - biolink:Drug
+  - biolink:DrugExposure
+  - biolink:EnvironmentalFeature
+  - biolink:EnvironmentalProcess
+  - biolink:Event
+  - biolink:EvidenceType
+  - biolink:Exon
+  - biolink:Fungus
+  - biolink:Gene
+  - biolink:GeneticInheritance
+  - biolink:Genome
+  - biolink:Genotype
+  - biolink:GenotypicSex
+  - biolink:GeographicExposure
+  - biolink:GrossAnatomicalStructure
+  - biolink:Haplotype
+  - biolink:Human
+  - biolink:IndividualOrganism
+  - biolink:InformationContentEntity
+  - biolink:Invertebrate
+  - biolink:LifeStage
+  - biolink:MacromolecularComplex
+  - biolink:Mammal
+  - biolink:MaterialSample
+  - biolink:MicroRNA
+  - biolink:MolecularActivity
+  - biolink:MolecularEntity
+  - biolink:NamedThing
+  - biolink:NoncodingRNAProduct
+  - biolink:NucleicAcidEntity
+  - biolink:OrganismTaxon
+  - biolink:OrganismalEntity
+  - biolink:Patent
+  - biolink:PathologicalProcess
+  - biolink:Pathway
+  - biolink:PhenotypicFeature
+  - biolink:PhenotypicQuality
+  - biolink:PhenotypicSex
+  - biolink:Plant
+  - biolink:Polypeptide
+  - biolink:PopulationOfIndividualOrganisms
+  - biolink:Procedure
+  - biolink:ProcessedMaterial
+  - biolink:Protein
+  - biolink:ProteinDomain
+  - biolink:ProteinFamily
+  - biolink:Publication
+  - biolink:RNAProduct
+  - biolink:ReagentTargetedGene
+  - biolink:RegulatoryRegion
+  - biolink:SiRNA
+  - biolink:SmallMolecule
+  - biolink:Snv
+  - biolink:Study
+  - biolink:StudyVariable
+  - biolink:Transcript
+  - biolink:TranscriptionFactorBindingSite
+  - biolink:Treatment
+  - biolink:Vertebrate
+  - biolink:Virus
+  - biolink:WebPage
+  - biolink:Zygosity
+  node_id_prefixes:
+  - APO
+  - BFO
+  - BSPO
+  - BTO
+  - CARO
+  - CHEBI
+  - CHR
+  - CIO
+  - CL
+  - CLO
+  - DATACOMMONS
+  - DOAP
+  - DOID
+  - ECO
+  - ECTO
+  - EMAPA
+  - ENVO
+  - FAO
+  - FB
+  - FBbt
+  - FBcv
+  - FMA
+  - FOODON
+  - FYPO
+  - GENO
+  - GO
+  - GOREL
+  - HGNC
+  - HP
+  - HSAPDV
+  - IAO
+  - LINKML
+  - MA
+  - MAXO
+  - MESH
+  - MF
+  - MFOMD
+  - MGI
+  - MOD
+  - MONDO
+  - MP
+  - MPATH
+  - NBO
+  - NCBIGene
+  - NCBITaxon
+  - NCIT
+  - NIF.EXT
+  - NIF.STD
+  - NLX.OEN
+  - NLX.SUB
+  - OBA
+  - OBI
+  - OBO
+  - OGMS
+  - OIO
+  - OMIT
+  - OMO
+  - Orphanet
+  - PATO
+  - PCO
+  - PHENIO
+  - PO
+  - PR
+  - PROV
+  - PW
+  - PomBase
+  - REACT
+  - RGD
+  - RNORDV
+  - RO
+  - SEPIO
+  - SGD
+  - SIO
+  - SNOMED
+  - SNOMEDCT
+  - SO
+  - STATO
+  - TO
+  - TS
+  - UBERON
+  - UBPROP
+  - UMLS
+  - UPHENO
+  - WB
+  - WBLS
+  - WBPhenotype
+  - WBbt
+  - XAO
+  - XPO
+  - Xenbase
+  - ZFA
+  - ZFIN
+  - ZFS
+  - ZP
+  - dc
+  - dcat
+  - dcterms
+  - dctypes
+  - dictyBase
+  - foaf
+  - owl
+  - rdfs
+  node_id_prefixes_by_category:
+    biolink:AccessibleDnaRegion:
+    - SO
+    biolink:Activity:
+    - NCIT
+    - PROV
+    biolink:Agent:
+    - dcterms
+    - PROV
+    biolink:AnatomicalEntity:
+    - CARO
+    - EMAPA
+    - FBbt
+    - FMA
+    - MA
+    - NCIT
+    - UBERON
+    - WBbt
+    - XAO
+    - ZFA
+    - SIO
+    - NIF.STD
+    - NIF.EXT
+    biolink:Article:
+    - SIO
+    biolink:Attribute:
+    - SIO
+    biolink:Bacterium:
+    - NCBITaxon
+    biolink:BehavioralFeature:
+    - NBO
+    biolink:BiologicalEntity:
+    - SIO
+    biolink:BiologicalProcess:
+    - GO
+    - SIO
+    biolink:BiologicalProcessOrActivity:
+    - BFO
+    - FMA
+    - GO
+    - IAO
+    - NBO
+    - OBI
+    - PO
+    - RO
+    - STATO
+    - UBERON
+    biolink:BiologicalSex:
+    - PATO
+    biolink:Cell:
+    - CL
+    - EMAPA
+    - FBbt
+    - FMA
+    - GO
+    - MA
+    - WBbt
+    - ZFA
+    - SIO
+    biolink:CellLine:
+    - CLO
+    biolink:CellularComponent:
+    - CL
+    - GO
+    - WBbt
+    - SIO
+    biolink:CellularOrganism:
+    - NCBITaxon
+    biolink:ChemicalEntity:
+    - CHEBI
+    - SIO
+    biolink:ChemicalExposure:
+    - ECTO
+    - SIO
+    biolink:ChemicalMixture:
+    - NCIT
+    biolink:CodingSequence:
+    - SIO
+    biolink:ConfidenceLevel:
+    - CIO
+    - SEPIO
+    biolink:Dataset:
+    - dctypes
+    - DATACOMMONS
+    biolink:DatasetDistribution:
+    - dcat
+    biolink:DiagnosticAid:
+    - SNOMED
+    biolink:Disease:
+    - MESH
+    - SNOMEDCT
+    - UMLS
+    - DOID
+    - MONDO
+    - NCIT
+    - SIO
+    - Orphanet
+    - DATACOMMONS
+    biolink:Drug:
+    - CHEBI
+    - DATACOMMONS
+    biolink:DrugExposure:
+    - ECTO
+    biolink:EnvironmentalFeature:
+    - ENVO
+    biolink:EnvironmentalProcess:
+    - ENVO
+    biolink:Event:
+    - NCIT
+    biolink:EvidenceType:
+    - ECO
+    biolink:Exon:
+    - SO
+    - SIO
+    biolink:Fungus:
+    - FOODON
+    - NCBITaxon
+    - NCIT
+    biolink:Gene:
+    - PomBase
+    - ZFIN
+    - Xenbase
+    - WB
+    - SGD
+    - RGD
+    - MGI
+    - FB
+    - NCBIGene
+    - dictyBase
+    - HGNC
+    - SIO
+    - DATACOMMONS
+    biolink:GeneticInheritance:
+    - GENO
+    - NCIT
+    biolink:Genome:
+    - SO
+    - SIO
+    biolink:Genotype:
+    - GENO
+    - SIO
+    biolink:GenotypicSex:
+    - PATO
+    biolink:GeographicExposure:
+    - DATACOMMONS
+    biolink:GrossAnatomicalStructure:
+    - EMAPA
+    - FBbt
+    - FMA
+    - MA
+    - UBERON
+    - WBbt
+    - ZFA
+    - NIF.EXT
+    - NLX.SUB
+    - NLX.OEN
+    biolink:Haplotype:
+    - GENO
+    - SO
+    biolink:Human:
+    - NCIT
+    - SIO
+    biolink:IndividualOrganism:
+    - SIO
+    - foaf
+    biolink:InformationContentEntity:
+    - IAO
+    - ECO
+    - OBI
+    - STATO
+    - OBO
+    biolink:Invertebrate:
+    - FOODON
+    - NCIT
+    - OMIT
+    biolink:LifeStage:
+    - HSAPDV
+    biolink:MacromolecularComplex:
+    - CL
+    - GO
+    - PR
+    biolink:Mammal:
+    - FOODON
+    - NCIT
+    biolink:MaterialSample:
+    - OBI
+    - SIO
+    biolink:MicroRNA:
+    - SO
+    - SIO
+    biolink:MolecularActivity:
+    - GO
+    biolink:MolecularEntity:
+    - CHEBI
+    - PR
+    biolink:NamedThing:
+    - BFO
+    - BSPO
+    - BTO
+    - CARO
+    - CHR
+    - ECO
+    - ECTO
+    - EMAPA
+    - ENVO
+    - FAO
+    - FBbt
+    - FMA
+    - FYPO
+    - GO
+    - HSAPDV
+    - IAO
+    - MAXO
+    - MFOMD
+    - MF
+    - MOD
+    - MPATH
+    - MP
+    - NBO
+    - NCIT
+    - OBA
+    - OBI
+    - OGMS
+    - PATO
+    - PHENIO
+    - PO
+    - RO
+    - RNORDV
+    - TS
+    - UPHENO
+    - WBPhenotype
+    - WBbt
+    - WBLS
+    - XAO
+    - ZFA
+    - ZFS
+    - OBO
+    - owl
+    - foaf
+    - DATACOMMONS
+    - LINKML
+    - GOREL
+    - OMO
+    - STATO
+    - UBPROP
+    - dc
+    - dcterms
+    - DOAP
+    - OIO
+    - rdfs
+    biolink:NoncodingRNAProduct:
+    - SIO
+    biolink:NucleicAcidEntity:
+    - OBI
+    - SO
+    biolink:OrganismTaxon:
+    - DATACOMMONS
+    biolink:OrganismalEntity:
+    - CARO
+    - NCBITaxon
+    biolink:Patent:
+    - IAO
+    - SIO
+    biolink:PathologicalProcess:
+    - MPATH
+    - NCIT
+    - OBI
+    biolink:Pathway:
+    - REACT
+    - GO
+    - PW
+    - SIO
+    biolink:PhenotypicFeature:
+    - UMLS
+    - APO
+    - FBcv
+    - FYPO
+    - HP
+    - MP
+    - NCIT
+    - TO
+    - UPHENO
+    - WBPhenotype
+    - XPO
+    - ZP
+    - SIO
+    biolink:PhenotypicQuality:
+    - CHEBI
+    - MONDO
+    biolink:PhenotypicSex:
+    - PATO
+    biolink:Plant:
+    - NCIT
+    - PO
+    biolink:Polypeptide:
+    - SO
+    biolink:PopulationOfIndividualOrganisms:
+    - OBI
+    - PCO
+    - STATO
+    - SIO
+    biolink:Procedure:
+    - DATACOMMONS
+    biolink:ProcessedMaterial:
+    - OBI
+    biolink:Protein:
+    - CHEBI
+    - PR
+    - SIO
+    biolink:ProteinDomain:
+    - UMLS
+    - NCIT
+    - SIO
+    biolink:ProteinFamily:
+    - NCIT
+    - SIO
+    biolink:Publication:
+    - IAO
+    biolink:RNAProduct:
+    - CHEBI
+    - SO
+    biolink:ReagentTargetedGene:
+    - GENO
+    biolink:RegulatoryRegion:
+    - SO
+    - SIO
+    biolink:SiRNA:
+    - SO
+    biolink:SmallMolecule:
+    - CHEBI
+    biolink:Snv:
+    - SO
+    biolink:Study:
+    - NCIT
+    - SIO
+    biolink:StudyVariable:
+    - NCIT
+    biolink:Transcript:
+    - SO
+    - SIO
+    - DATACOMMONS
+    biolink:TranscriptionFactorBindingSite:
+    - SO
+    biolink:Treatment:
+    - OGMS
+    - SIO
+    biolink:Vertebrate:
+    - NCBITaxon
+    - OMIT
+    biolink:Virus:
+    - NCBITaxon
+    biolink:WebPage:
+    - OBO
+    - SIO
+    biolink:Zygosity:
+    - GENO
+    unknown: []
+  provided_by:
+  - alliance_gene_nodes
+  - dictybase_gene_nodes
+  - hgnc_gene_nodes
+  - ncbi_gene_nodes
+  - phenio_nodes
+  - pombase_gene_nodes
+  - reactome_pathway_nodes
+  total_nodes: 861530


### PR DESCRIPTION
This adds side-by-side tables of the Node Stats comparing the previous report.