### PR TITLE
Add Source Versions page

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: monarch-qc-dashboard
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: monarch-qc-dashboard/yarn.lock
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn vitest run
+
+      - run: yarn build

--- a/monarch-qc-dashboard/src/App.vue
+++ b/monarch-qc-dashboard/src/App.vue
@@ -5,6 +5,7 @@
   <main>
     <div>
       <button @click="selectSection('monarch')">Monarch-QC</button>
+      <button @click="selectSection('source-versions'); updateUrlHash('source-versions')">Source Versions</button>
       <button @click="selectSection('sri')">SRI-Reference Comparison</button>
       <button @click="selectSection('missing-nodes'); updateUrlHash('missing-nodes')">Missing Nodes</button>
       <UploadReport />
@@ -142,11 +143,37 @@
         </div>
       </div>
     </div>
+    <div v-if="selectedSection === 'source-versions'">
+      <img src="/src/global/monarch.png" class="logo" alt="Monarch Logo" />
+      <SelectReport
+        id="selectDataSetSources"
+        label=""
+        :reportNames="dataNames"
+        v-model="selectedData"
+        :onChange="updateData"
+      />
+      <SelectReport
+        id="selectCompareReportSources"
+        label="Compare to:"
+        :reportNames="compareNames"
+        v-model="selectedCompare"
+        :onChange="processReports"
+        :removeFrom="selectedReport"
+      />
+      <SelectReport
+        id="selectReportSources"
+        label="KG Release:"
+        :reportNames="[...globalReports.keys()]"
+        v-model="selectedReport"
+        :onChange="processReports"
+      />
+      <SourcesPage />
+    </div>
     <div v-if="selectedSection === 'missing-nodes'">
       <img src="/src/global/monarch.png" class="logo" alt="Monarch Logo" />
       <h1>Missing Nodes Explorer</h1>
-      <MissingNodes 
-        :initialIngest="selectedMissingNodesIngest" 
+      <MissingNodes
+        :initialIngest="selectedMissingNodesIngest"
         :dataSet="selectedData"
         :kgVersion="selectedReport"
       />
@@ -176,6 +203,7 @@
   import LineChart from "./components/LineChart.vue"
   import UploadReport from "./components/UploadReport.vue"
   import MissingNodes from "./components/MissingNodes.vue"
+  import SourcesPage from "./components/SourcesPage.vue"
 
   function isDarkMode() {
     return window.matchMedia("(prefers-color-scheme: dark)").matches

--- a/monarch-qc-dashboard/src/components/SourcesPage.vue
+++ b/monarch-qc-dashboard/src/components/SourcesPage.vue
@@ -101,6 +101,7 @@
           <th>Ingest version</th>
           <th>Transform</th>
           <th>Biolink</th>
+          <th>Via</th>
           <th>Source</th>
           <th>Name</th>
           <th>Version</th>
@@ -111,13 +112,17 @@
       <tbody>
         <tr
           v-for="row in byIngestGrouped"
-          :key="`${row.ingest}|${row.infores}|${row.version}`"
+          :key="`${row.ingest}|${row.via}|${row.infores}|${row.version}`"
           :class="{ 'group-start': row.groupStart }"
         >
           <td v-if="row.groupStart" :rowspan="row.groupSize"><code>{{ row.ingest }}</code></td>
           <td v-if="row.groupStart" :rowspan="row.groupSize" class="version"><code>{{ row.ingest_version }}</code></td>
           <td v-if="row.groupStart" :rowspan="row.groupSize"><code>{{ row.transform_version }}</code></td>
           <td v-if="row.groupStart" :rowspan="row.groupSize"><code>{{ row.biolink_version }}</code></td>
+          <td>
+            <code v-if="row.via">{{ row.via }}</code>
+            <span v-else class="muted">—</span>
+          </td>
           <td><code>{{ row.infores }}</code></td>
           <td>{{ row.name }}</td>
           <td class="version"><code>{{ row.version }}</code></td>

--- a/monarch-qc-dashboard/src/components/SourcesPage.vue
+++ b/monarch-qc-dashboard/src/components/SourcesPage.vue
@@ -90,6 +90,10 @@
       </tbody>
     </table>
 
+    <div v-if="view === 'ingest' && current && !byIngestGrouped.length" class="empty">
+      Receipt has no per-ingest builds with upstream sources.
+    </div>
+
     <table v-if="view === 'ingest' && byIngestGrouped.length">
       <thead>
         <tr>
@@ -131,9 +135,11 @@ import YAML from "yaml"
 import { globalMetadata, selectedReport, selectedCompare } from "../data"
 import {
   Release,
+  Disagreement,
   flattenSources,
   flattenByIngest,
   compareSources,
+  groupBy,
   ComparedRow,
   IngestSourceRow,
 } from "../sources_utils"
@@ -146,11 +152,18 @@ const view = ref<"source" | "ingest">("source")
 const currentVersion = computed(() => current.value?.version ?? "")
 const compareVersion = computed(() => previous.value?.version ?? "")
 
-const receiptDisagreements = computed(() => current.value?.disagreements ?? [])
-const receiptDrift = computed(() => current.value?.version_drift ?? [])
-const previousIsLegacy = computed(
-  () => previous.value !== null && !(previous.value.sources && previous.value.sources.length)
+function sortByIngest(d: Disagreement): Disagreement {
+  return { ...d, by_ingest: Object.fromEntries(Object.entries(d.by_ingest).sort(([a], [b]) => a.localeCompare(b))) }
+}
+
+const receiptDisagreements = computed(
+  () => (current.value?.disagreements ?? []).map(sortByIngest)
 )
+const receiptDrift = computed(
+  () => (current.value?.version_drift ?? []).map(sortByIngest)
+)
+// A new-format receipt always has a top-level `id`; legacy receipts don't.
+const previousIsLegacy = computed(() => previous.value !== null && !previous.value.id)
 
 interface BySourceGroupedRow extends ComparedRow {
   groupStart: boolean
@@ -176,27 +189,6 @@ const byIngestGrouped = computed<ByIngestGroupedRow[]>(() => {
   return groupBy(rows, (r) => r.ingest)
 })
 
-function groupBy<T extends object>(
-  rows: T[],
-  key: (r: T) => string
-): (T & { groupStart: boolean; groupSize: number })[] {
-  const out: (T & { groupStart: boolean; groupSize: number })[] = []
-  let lastKey: string | null = null
-  let startIdx = -1
-  for (const row of rows) {
-    const k = key(row)
-    if (k !== lastKey) {
-      out.push({ ...row, groupStart: true, groupSize: 1 })
-      lastKey = k
-      startIdx = out.length - 1
-    } else {
-      out[startIdx].groupSize++
-      out.push({ ...row, groupStart: false, groupSize: 1 })
-    }
-  }
-  return out
-}
-
 async function loadReceipt(name: string): Promise<Release | null> {
   const promise = globalMetadata.value.get(name)
   if (!promise) return null
@@ -209,7 +201,11 @@ async function loadReceipt(name: string): Promise<Release | null> {
   }
 }
 
+// Token-based race protection: rapid changes to selectedReport / selectedCompare
+// can fire overlapping refreshes; only the most recent one is allowed to commit.
+let refreshToken = 0
 async function refresh() {
+  const my = ++refreshToken
   if (!selectedReport.value) {
     current.value = null
     previous.value = null
@@ -221,10 +217,11 @@ async function refresh() {
       loadReceipt(selectedReport.value),
       selectedCompare.value ? loadReceipt(selectedCompare.value) : Promise.resolve(null),
     ])
+    if (my !== refreshToken) return
     current.value = cur
     previous.value = prev
   } finally {
-    loading.value = false
+    if (my === refreshToken) loading.value = false
   }
 }
 
@@ -232,34 +229,58 @@ watch([selectedReport, selectedCompare, globalMetadata], refresh, { immediate: t
 </script>
 
 <style scoped>
+/* Status / alert tints use semitransparent overlays so they read on either
+   the light or dark global background (default is dark; @media light in
+   style.css flips it). */
 .sources-page { padding: 1rem; }
-.subtitle { color: #666; margin-top: 0; }
+.subtitle { opacity: 0.7; margin-top: 0; }
+
 .view-toggle { margin: 1rem 0; }
 .view-toggle button {
-  border: 1px solid #ccc; background: #fff; padding: 0.4rem 0.9rem; cursor: pointer;
+  border: 1px solid currentColor;
+  opacity: 0.6;
+  background: transparent;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
   border-radius: 0;
 }
 .view-toggle button:first-child { border-top-left-radius: 4px; border-bottom-left-radius: 4px; }
 .view-toggle button:last-child { border-top-right-radius: 4px; border-bottom-right-radius: 4px; border-left: none; }
-.view-toggle button.active { background: #2c3e50; color: #fff; border-color: #2c3e50; }
+.view-toggle button.active { opacity: 1; background: rgba(127, 127, 127, 0.2); }
 
 .alerts { margin: 1rem 0; }
-.alert { padding: 0.5rem 0.75rem; border-radius: 4px; margin-bottom: 0.5rem; }
-.alert.disagreement { background: #fde8e8; border: 1px solid #f5a3a3; }
-.alert.drift { background: #fff7e8; border: 1px solid #f0d089; }
+.alert {
+  padding: 0.5rem 0.75rem; border-radius: 4px; margin-bottom: 0.5rem;
+  border: 1px solid currentColor;
+}
+.alert.disagreement { background: rgba(220, 80, 80, 0.18); }
+.alert.drift { background: rgba(220, 160, 60, 0.18); }
 .alert summary { cursor: pointer; }
 .badge { display: inline-block; margin-left: 0.5em; font-size: 0.9em; }
 
 table { border-collapse: collapse; width: 100%; font-size: 0.95em; }
-th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid #ddd; vertical-align: top; }
-th { background: #f5f5f5; }
+th, td {
+  text-align: left; padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.25);
+  vertical-align: top;
+}
+th { background: rgba(127, 127, 127, 0.15); }
 td.version { white-space: nowrap; }
 /* Strong divider at the top of each group so repeated rows feel attached. */
-tr.group-start > td { border-top: 2px solid #cfd6dd; }
-tr:not(.group-start) > td { border-bottom: 1px solid #eee; }
-tr.added { background: #e8f5e9; }
-tr.removed { background: #ffebee; opacity: 0.75; }
-.muted { color: #999; }
-.empty, .loading { padding: 1rem; color: #666; }
-.legacy-note { padding: 0.5rem 0.75rem; margin-bottom: 0.75rem; background: #eef4ff; border: 1px solid #b9cdf0; border-radius: 4px; font-size: 0.95em; }
+tr.group-start > td { border-top: 2px solid rgba(127, 127, 127, 0.45); }
+tr:not(.group-start) > td { border-bottom: 1px solid rgba(127, 127, 127, 0.12); }
+/* Status: tint background and (for removed) strike through the version cell —
+   stronger accessibility than reduced opacity. */
+tr.added { background: rgba(80, 180, 100, 0.18); }
+tr.removed { background: rgba(220, 80, 80, 0.18); }
+tr.removed td.version code { text-decoration: line-through; }
+
+.muted { opacity: 0.5; }
+.empty, .loading { padding: 1rem; opacity: 0.7; }
+.legacy-note {
+  padding: 0.5rem 0.75rem; margin-bottom: 0.75rem;
+  background: rgba(80, 130, 220, 0.18);
+  border: 1px solid currentColor;
+  border-radius: 4px; font-size: 0.95em;
+}
 </style>

--- a/monarch-qc-dashboard/src/components/SourcesPage.vue
+++ b/monarch-qc-dashboard/src/components/SourcesPage.vue
@@ -1,0 +1,265 @@
+<!--
+  Renders the upstream-source view of the build receipt (metadata.yaml,
+  kozahub-metadata-schema). Two views:
+  - "by source": one row per (infores, version), grouped visually by infores.
+  - "by ingest": one row per (ingest, infores, version), grouped by ingest.
+  Plus the receipt's disagreements/version-drift warnings at the top.
+-->
+<template>
+  <div class="sources-page">
+    <h1>Source Versions</h1>
+    <p class="subtitle">
+      Upstream sources consumed by monarch-kg
+      <span v-if="currentVersion"> — release <strong>{{ currentVersion }}</strong></span>
+      <span v-if="compareVersion"> compared to <strong>{{ compareVersion }}</strong></span>
+    </p>
+
+    <div v-if="!current && !loading" class="empty">
+      No <code>metadata.yaml</code> available for the selected release.
+    </div>
+    <div v-if="loading" class="loading">Loading…</div>
+    <div v-if="previous && previousIsLegacy" class="legacy-note">
+      The compare release predates the recursive build-receipt format —
+      previous-version columns will be blank.
+    </div>
+
+    <div v-if="current" class="view-toggle">
+      <button :class="{ active: view === 'source' }" @click="view = 'source'">By source</button>
+      <button :class="{ active: view === 'ingest' }" @click="view = 'ingest'">By ingest</button>
+    </div>
+
+    <section v-if="receiptDisagreements.length || receiptDrift.length" class="alerts">
+      <details v-if="receiptDisagreements.length" open class="alert disagreement">
+        <summary>
+          <strong>{{ receiptDisagreements.length }}</strong> tagged-version disagreement(s)
+          across ingests
+        </summary>
+        <ul>
+          <li v-for="d in receiptDisagreements" :key="d.id">
+            <code>{{ d.id }}</code>:
+            <span v-for="(v, ingest) in d.by_ingest" :key="ingest" class="badge">
+              {{ ingest }}=<code>{{ v }}</code>
+            </span>
+          </li>
+        </ul>
+      </details>
+      <details v-if="receiptDrift.length" class="alert drift">
+        <summary>
+          <strong>{{ receiptDrift.length }}</strong> rolling-source drift (informational)
+        </summary>
+        <ul>
+          <li v-for="d in receiptDrift" :key="d.id">
+            <code>{{ d.id }}</code>:
+            <span v-for="(v, ingest) in d.by_ingest" :key="ingest" class="badge">
+              {{ ingest }}=<code>{{ v }}</code>
+            </span>
+          </li>
+        </ul>
+      </details>
+    </section>
+
+    <table v-if="view === 'source' && bySourceGrouped.length">
+      <thead>
+        <tr>
+          <th>Source</th>
+          <th>Name</th>
+          <th>Version</th>
+          <th>Δ</th>
+          <th>Method</th>
+          <th>Retrieved</th>
+          <th>Consumed by</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="row in bySourceGrouped"
+          :key="`${row.infores}|${row.version}|${row.status}`"
+          :class="{ added: row.status === 'added', removed: row.status === 'removed', 'group-start': row.groupStart }"
+        >
+          <td v-if="row.groupStart" :rowspan="row.groupSize"><code>{{ row.infores }}</code></td>
+          <td v-if="row.groupStart" :rowspan="row.groupSize">{{ row.name }}</td>
+          <td class="version"><code>{{ row.version }}</code></td>
+          <td>
+            <span v-if="row.status === 'added'">+</span>
+            <span v-else-if="row.status === 'removed'">−</span>
+          </td>
+          <td>{{ row.version_method }}</td>
+          <td>{{ row.retrieved_at }}</td>
+          <td>{{ row.consumed_by.join(", ") }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <table v-if="view === 'ingest' && byIngestGrouped.length">
+      <thead>
+        <tr>
+          <th>Ingest</th>
+          <th>Ingest version</th>
+          <th>Transform</th>
+          <th>Biolink</th>
+          <th>Source</th>
+          <th>Name</th>
+          <th>Version</th>
+          <th>Method</th>
+          <th>Retrieved</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="row in byIngestGrouped"
+          :key="`${row.ingest}|${row.infores}|${row.version}`"
+          :class="{ 'group-start': row.groupStart }"
+        >
+          <td v-if="row.groupStart" :rowspan="row.groupSize"><code>{{ row.ingest }}</code></td>
+          <td v-if="row.groupStart" :rowspan="row.groupSize" class="version"><code>{{ row.ingest_version }}</code></td>
+          <td v-if="row.groupStart" :rowspan="row.groupSize"><code>{{ row.transform_version }}</code></td>
+          <td v-if="row.groupStart" :rowspan="row.groupSize"><code>{{ row.biolink_version }}</code></td>
+          <td><code>{{ row.infores }}</code></td>
+          <td>{{ row.name }}</td>
+          <td class="version"><code>{{ row.version }}</code></td>
+          <td>{{ row.version_method }}</td>
+          <td>{{ row.retrieved_at }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue"
+import YAML from "yaml"
+import { globalMetadata, selectedReport, selectedCompare } from "../data"
+import {
+  Release,
+  flattenSources,
+  flattenByIngest,
+  compareSources,
+  ComparedRow,
+  IngestSourceRow,
+} from "../sources_utils"
+
+const current = ref<Release | null>(null)
+const previous = ref<Release | null>(null)
+const loading = ref(false)
+const view = ref<"source" | "ingest">("source")
+
+const currentVersion = computed(() => current.value?.version ?? "")
+const compareVersion = computed(() => previous.value?.version ?? "")
+
+const receiptDisagreements = computed(() => current.value?.disagreements ?? [])
+const receiptDrift = computed(() => current.value?.version_drift ?? [])
+const previousIsLegacy = computed(
+  () => previous.value !== null && !(previous.value.sources && previous.value.sources.length)
+)
+
+interface BySourceGroupedRow extends ComparedRow {
+  groupStart: boolean
+  groupSize: number
+}
+
+const bySourceGrouped = computed<BySourceGroupedRow[]>(() => {
+  if (!current.value) return []
+  const cur = flattenSources(current.value)
+  const prev = previous.value ? flattenSources(previous.value) : null
+  const rows = compareSources(cur, prev)
+  return groupBy(rows, (r) => r.infores)
+})
+
+interface ByIngestGroupedRow extends IngestSourceRow {
+  groupStart: boolean
+  groupSize: number
+}
+
+const byIngestGrouped = computed<ByIngestGroupedRow[]>(() => {
+  if (!current.value) return []
+  const rows = flattenByIngest(current.value)
+  return groupBy(rows, (r) => r.ingest)
+})
+
+function groupBy<T extends object>(
+  rows: T[],
+  key: (r: T) => string
+): (T & { groupStart: boolean; groupSize: number })[] {
+  const out: (T & { groupStart: boolean; groupSize: number })[] = []
+  let lastKey: string | null = null
+  let startIdx = -1
+  for (const row of rows) {
+    const k = key(row)
+    if (k !== lastKey) {
+      out.push({ ...row, groupStart: true, groupSize: 1 })
+      lastKey = k
+      startIdx = out.length - 1
+    } else {
+      out[startIdx].groupSize++
+      out.push({ ...row, groupStart: false, groupSize: 1 })
+    }
+  }
+  return out
+}
+
+async function loadReceipt(name: string): Promise<Release | null> {
+  const promise = globalMetadata.value.get(name)
+  if (!promise) return null
+  try {
+    const text = await promise
+    return YAML.parse(text) as Release
+  } catch (err) {
+    console.error("Failed to load metadata.yaml for", name, err)
+    return null
+  }
+}
+
+async function refresh() {
+  if (!selectedReport.value) {
+    current.value = null
+    previous.value = null
+    return
+  }
+  loading.value = true
+  try {
+    const [cur, prev] = await Promise.all([
+      loadReceipt(selectedReport.value),
+      selectedCompare.value ? loadReceipt(selectedCompare.value) : Promise.resolve(null),
+    ])
+    current.value = cur
+    previous.value = prev
+  } finally {
+    loading.value = false
+  }
+}
+
+watch([selectedReport, selectedCompare, globalMetadata], refresh, { immediate: true })
+</script>
+
+<style scoped>
+.sources-page { padding: 1rem; }
+.subtitle { color: #666; margin-top: 0; }
+.view-toggle { margin: 1rem 0; }
+.view-toggle button {
+  border: 1px solid #ccc; background: #fff; padding: 0.4rem 0.9rem; cursor: pointer;
+  border-radius: 0;
+}
+.view-toggle button:first-child { border-top-left-radius: 4px; border-bottom-left-radius: 4px; }
+.view-toggle button:last-child { border-top-right-radius: 4px; border-bottom-right-radius: 4px; border-left: none; }
+.view-toggle button.active { background: #2c3e50; color: #fff; border-color: #2c3e50; }
+
+.alerts { margin: 1rem 0; }
+.alert { padding: 0.5rem 0.75rem; border-radius: 4px; margin-bottom: 0.5rem; }
+.alert.disagreement { background: #fde8e8; border: 1px solid #f5a3a3; }
+.alert.drift { background: #fff7e8; border: 1px solid #f0d089; }
+.alert summary { cursor: pointer; }
+.badge { display: inline-block; margin-left: 0.5em; font-size: 0.9em; }
+
+table { border-collapse: collapse; width: 100%; font-size: 0.95em; }
+th, td { text-align: left; padding: 0.4rem 0.6rem; border-bottom: 1px solid #ddd; vertical-align: top; }
+th { background: #f5f5f5; }
+td.version { white-space: nowrap; }
+/* Strong divider at the top of each group so repeated rows feel attached. */
+tr.group-start > td { border-top: 2px solid #cfd6dd; }
+tr:not(.group-start) > td { border-bottom: 1px solid #eee; }
+tr.added { background: #e8f5e9; }
+tr.removed { background: #ffebee; opacity: 0.75; }
+.muted { color: #999; }
+.empty, .loading { padding: 1rem; color: #666; }
+.legacy-note { padding: 0.5rem 0.75rem; margin-bottom: 0.75rem; background: #eef4ff; border: 1px solid #b9cdf0; border-radius: 4px; font-size: 0.95em; }
+</style>

--- a/monarch-qc-dashboard/src/data.ts
+++ b/monarch-qc-dashboard/src/data.ts
@@ -194,9 +194,14 @@ export async function updateData() {
 
   const qcsite = qcbase + qcdata.get(selectedData.value)
   const qctext: string = await fetchData(qcsite)
-  globalReports.value = await fetchQCReports(qctext, "qc_report.yaml")
-  globalStats.value = await fetchQCReports(qctext, "merged_graph_stats.yaml")
-  globalMetadata.value = await fetchQCReports(qctext, "metadata.yaml")
+  const [reports, stats, metadata] = await Promise.all([
+    fetchQCReports(qctext, "qc_report.yaml"),
+    fetchQCReports(qctext, "merged_graph_stats.yaml"),
+    fetchQCReports(qctext, "metadata.yaml"),
+  ])
+  globalReports.value = reports
+  globalStats.value = stats
+  globalMetadata.value = metadata
 
   // remove "latest" from qcReports, since it's always a duplicate of the most recent release
   globalReports.value.delete("latest")

--- a/monarch-qc-dashboard/src/data.ts
+++ b/monarch-qc-dashboard/src/data.ts
@@ -10,6 +10,7 @@ import { LineChartData } from "./components/LineChart"
 
 export const globalReports = ref<Map<string, Promise<string>>>(new Map())
 export const globalStats = ref<Map<string, Promise<string>>>(new Map())
+export const globalMetadata = ref<Map<string, Promise<string>>>(new Map())
 
 export const sriFetched = ref<boolean>(false)
 export const v3Stats = ref<Promise<string>>()
@@ -195,10 +196,12 @@ export async function updateData() {
   const qctext: string = await fetchData(qcsite)
   globalReports.value = await fetchQCReports(qctext, "qc_report.yaml")
   globalStats.value = await fetchQCReports(qctext, "merged_graph_stats.yaml")
+  globalMetadata.value = await fetchQCReports(qctext, "metadata.yaml")
 
   // remove "latest" from qcReports, since it's always a duplicate of the most recent release
   globalReports.value.delete("latest")
   globalStats.value.delete("latest")
+  globalMetadata.value.delete("latest")
 
   selectedReport.value = [...globalReports.value.keys()].slice(-1)[0] ?? ""
   dataNames.value = [...qcdata.keys()]

--- a/monarch-qc-dashboard/src/sources_utils.ts
+++ b/monarch-qc-dashboard/src/sources_utils.ts
@@ -173,6 +173,34 @@ function pairKey(r: SourceRow): string {
   return `${r.infores}|${r.version}`
 }
 
+/**
+ * Bucket consecutive rows that share a key. Sorts by `key()` first so the
+ * grouping doesn't depend on the caller's order; the resulting first-of-group
+ * row carries `groupSize` for use as a `rowspan`.
+ */
+export function groupBy<T extends object>(
+  rows: T[],
+  key: (r: T) => string
+): (T & { groupStart: boolean; groupSize: number })[] {
+  const sorted = [...rows].sort((a, b) => key(a).localeCompare(key(b)))
+  const out: (T & { groupStart: boolean; groupSize: number })[] = []
+  let lastKey: string | null = null
+  let startIdx = -1
+  for (const row of sorted) {
+    const k = key(row)
+    if (k !== lastKey) {
+      out.push({ ...row, groupStart: true, groupSize: 1 })
+      lastKey = k
+      startIdx = out.length - 1
+    } else {
+      out[startIdx].groupSize++
+      out.push({ ...row, groupStart: false, groupSize: 1 })
+    }
+  }
+  return out
+}
+
+
 export function compareSources(
   current: SourceRow[],
   previous: SourceRow[] | null

--- a/monarch-qc-dashboard/src/sources_utils.ts
+++ b/monarch-qc-dashboard/src/sources_utils.ts
@@ -1,0 +1,202 @@
+/**
+ * Utilities for parsing the recursive `Release` shape published in
+ * `metadata.yaml` (kozahub-metadata-schema) and flattening it into
+ * leaf-source rows for display.
+ *
+ * The receipt nests per-ingest builds underneath the top-level KG build,
+ * with each ingest carrying its own upstream `sources`. We treat any node
+ * with no nested `sources` as a leaf — i.e. an upstream `infores:*` data
+ * source consumed by one or more ingests.
+ */
+
+export interface Release {
+  id: string
+  name?: string
+  version?: string
+  version_method?: string
+  retrieved_at?: string
+  urls?: string[]
+  build_version?: string
+  generated_at?: string
+  transform_version?: string
+  biolink_version?: string
+  sources?: Release[]
+  artifacts?: { path: string; sha256?: string }[]
+  tools?: Record<string, string>
+  packages?: Record<string, string>
+  disagreements?: Disagreement[]
+  version_drift?: Disagreement[]
+}
+
+export interface Disagreement {
+  id: string
+  versions_observed: string[]
+  by_ingest: Record<string, string>
+}
+
+/**
+ * One row per (infores, version) tuple. When several ingests captured the
+ * same source at the same version, they're grouped here under `consumed_by`.
+ * When ingests captured different versions, they emit separate rows that
+ * sort adjacently — so a disagreement appears visually as two rows for the
+ * same infores rather than a single row with a stacked cell.
+ */
+export interface SourceRow {
+  infores: string
+  name: string
+  version: string
+  version_method: string
+  retrieved_at: string
+  urls: string[]
+  consumed_by: string[]
+}
+
+/**
+ * Walk the Release tree. For each leaf source (no nested `sources`), emit
+ * one merged row keyed by `infores`, recording every contributing ingest.
+ * If different ingests captured different versions of the same source, the
+ * row's `version` is `"DISAGREE"` — the underlying conflict is also reported
+ * via the receipt's top-level `disagreements`/`version_drift`.
+ */
+export function flattenSources(receipt: Release | null | undefined): SourceRow[] {
+  if (!receipt) return []
+  const byPair = new Map<string, SourceRow>()
+
+  function visit(node: Release, ancestorIngest: string | null) {
+    const childSources = node.sources ?? []
+    const isBuild = childSources.length > 0
+    // The closest non-leaf ancestor is the contributing ingest.
+    const ingestForChildren = isBuild ? node.id : ancestorIngest
+    if (!isBuild) {
+      // Legacy receipts (`kg-version`/`packages`/`data:` shape) have no `id`
+      // and no nested sources — skip rather than emit an undefined-keyed row.
+      if (!node.id) return
+      const ver = node.version ?? ""
+      const key = `${node.id}|${ver}`
+      const existing = byPair.get(key)
+      if (existing) {
+        if (ancestorIngest && !existing.consumed_by.includes(ancestorIngest)) {
+          existing.consumed_by.push(ancestorIngest)
+        }
+      } else {
+        byPair.set(key, {
+          infores: node.id,
+          name: node.name ?? "",
+          version: ver,
+          version_method: node.version_method ?? "",
+          retrieved_at: node.retrieved_at ?? "",
+          urls: node.urls ?? [],
+          consumed_by: ancestorIngest ? [ancestorIngest] : [],
+        })
+      }
+      return
+    }
+    for (const child of childSources) visit(child, ingestForChildren)
+  }
+
+  visit(receipt, null)
+  return [...byPair.values()].sort(
+    (a, b) =>
+      (a.infores ?? "").localeCompare(b.infores ?? "") ||
+      (a.version ?? "").localeCompare(b.version ?? "")
+  )
+}
+
+/** One row per (ingest, infores, version) — the by-ingest view. */
+export interface IngestSourceRow {
+  ingest: string
+  ingest_version: string
+  transform_version: string
+  biolink_version: string
+  build_version: string
+  generated_at: string
+  infores: string
+  name: string
+  version: string
+  version_method: string
+  retrieved_at: string
+  urls: string[]
+}
+
+/**
+ * Flatten the receipt to per-ingest rows. Each immediate child of the root is
+ * a per-ingest build; for each, emit one row per leaf upstream source.
+ */
+export function flattenByIngest(
+  receipt: Release | null | undefined
+): IngestSourceRow[] {
+  if (!receipt) return []
+  const rows: IngestSourceRow[] = []
+  for (const build of receipt.sources ?? []) {
+    if (!build.id) continue
+    const leaves = build.sources ?? []
+    if (leaves.length === 0) continue
+    for (const leaf of leaves) {
+      if (!leaf.id) continue
+      rows.push({
+        ingest: build.id,
+        ingest_version: build.version ?? "",
+        transform_version: build.transform_version ?? "",
+        biolink_version: build.biolink_version ?? "",
+        build_version: build.build_version ?? "",
+        generated_at: build.generated_at ?? "",
+        infores: leaf.id,
+        name: leaf.name ?? "",
+        version: leaf.version ?? "",
+        version_method: leaf.version_method ?? "",
+        retrieved_at: leaf.retrieved_at ?? "",
+        urls: leaf.urls ?? [],
+      })
+    }
+  }
+  return rows.sort(
+    (a, b) =>
+      a.ingest.localeCompare(b.ingest) ||
+      a.infores.localeCompare(b.infores) ||
+      a.version.localeCompare(b.version)
+  )
+}
+
+/**
+ * Merge `current` and `previous` row sets on the (infores, version) pair.
+ *
+ * A row in current that's also in previous => `unchanged`. A row only in
+ * current => `added` (new (infores, version) tuple). A row only in previous
+ * => `removed`. When an infores's version bumps, you get one `removed` and
+ * one `added` row at consecutive (sorted) positions for that infores.
+ */
+export interface ComparedRow extends SourceRow {
+  status: "added" | "removed" | "unchanged"
+}
+
+function pairKey(r: SourceRow): string {
+  return `${r.infores}|${r.version}`
+}
+
+export function compareSources(
+  current: SourceRow[],
+  previous: SourceRow[] | null
+): ComparedRow[] {
+  if (!previous) return current.map((row) => ({ ...row, status: "unchanged" }))
+
+  const prevByPair = new Map<string, SourceRow>()
+  for (const r of previous) prevByPair.set(pairKey(r), r)
+  const seen = new Set<string>()
+
+  const out: ComparedRow[] = current.map((row) => {
+    const key = pairKey(row)
+    seen.add(key)
+    return { ...row, status: prevByPair.has(key) ? "unchanged" : "added" }
+  })
+
+  for (const prev of previous) {
+    if (seen.has(pairKey(prev))) continue
+    out.push({ ...prev, status: "removed" })
+  }
+
+  return out.sort(
+    (a, b) =>
+      (a.infores ?? "").localeCompare(b.infores ?? "") ||
+      (a.version ?? "").localeCompare(b.version ?? "")
+  )
+}

--- a/monarch-qc-dashboard/src/sources_utils.ts
+++ b/monarch-qc-dashboard/src/sources_utils.ts
@@ -62,21 +62,25 @@ export function flattenSources(receipt: Release | null | undefined): SourceRow[]
   if (!receipt) return []
   const byPair = new Map<string, SourceRow>()
 
-  function visit(node: Release, ancestorIngest: string | null) {
+  // ancestorPath is the chain of non-leaf ancestor IDs from the root down,
+  // including the root itself. The leaf's `consumed_by` is the path with the
+  // root sliced off (it's the same for every leaf), joined with "/" so a
+  // 3-deep leaf reads as e.g. "kg-phenio/phenio".
+  function visit(node: Release, ancestorPath: string[]) {
     const childSources = node.sources ?? []
     const isBuild = childSources.length > 0
-    // The closest non-leaf ancestor is the contributing ingest.
-    const ingestForChildren = isBuild ? node.id : ancestorIngest
+    const newPath = isBuild && node.id ? [...ancestorPath, node.id] : ancestorPath
     if (!isBuild) {
       // Legacy receipts (`kg-version`/`packages`/`data:` shape) have no `id`
       // and no nested sources — skip rather than emit an undefined-keyed row.
       if (!node.id) return
       const ver = node.version ?? ""
       const key = `${node.id}|${ver}`
+      const pathStr = ancestorPath.slice(1).join("/")
       const existing = byPair.get(key)
       if (existing) {
-        if (ancestorIngest && !existing.consumed_by.includes(ancestorIngest)) {
-          existing.consumed_by.push(ancestorIngest)
+        if (pathStr && !existing.consumed_by.includes(pathStr)) {
+          existing.consumed_by.push(pathStr)
         }
       } else {
         byPair.set(key, {
@@ -86,15 +90,15 @@ export function flattenSources(receipt: Release | null | undefined): SourceRow[]
           version_method: node.version_method ?? "",
           retrieved_at: node.retrieved_at ?? "",
           urls: node.urls ?? [],
-          consumed_by: ancestorIngest ? [ancestorIngest] : [],
+          consumed_by: pathStr ? [pathStr] : [],
         })
       }
       return
     }
-    for (const child of childSources) visit(child, ingestForChildren)
+    for (const child of childSources) visit(child, newPath)
   }
 
-  visit(receipt, null)
+  visit(receipt, [])
   return [...byPair.values()].sort(
     (a, b) =>
       (a.infores ?? "").localeCompare(b.infores ?? "") ||
@@ -110,6 +114,10 @@ export interface IngestSourceRow {
   biolink_version: string
   build_version: string
   generated_at: string
+  // For sources reached through intermediate builds (e.g. an ontology under
+  // phenio under kg-phenio), the slash-separated path of intermediate build
+  // ids — empty for direct-leaf cases. e.g. "phenio".
+  via: string
   infores: string
   name: string
   version: string
@@ -119,8 +127,10 @@ export interface IngestSourceRow {
 }
 
 /**
- * Flatten the receipt to per-ingest rows. Each immediate child of the root is
- * a per-ingest build; for each, emit one row per leaf upstream source.
+ * Flatten the receipt to per-ingest rows. The "ingest" is the immediate child
+ * of the root. Each subtree under it is walked recursively, and every terminal
+ * leaf (no nested sources) becomes a row, with `via` capturing any intermediate
+ * builds traversed (e.g. "phenio" for an ontology under kg-phenio).
  */
 export function flattenByIngest(
   receipt: Release | null | undefined
@@ -129,29 +139,37 @@ export function flattenByIngest(
   const rows: IngestSourceRow[] = []
   for (const build of receipt.sources ?? []) {
     if (!build.id) continue
-    const leaves = build.sources ?? []
-    if (leaves.length === 0) continue
-    for (const leaf of leaves) {
-      if (!leaf.id) continue
-      rows.push({
-        ingest: build.id,
-        ingest_version: build.version ?? "",
-        transform_version: build.transform_version ?? "",
-        biolink_version: build.biolink_version ?? "",
-        build_version: build.build_version ?? "",
-        generated_at: build.generated_at ?? "",
-        infores: leaf.id,
-        name: leaf.name ?? "",
-        version: leaf.version ?? "",
-        version_method: leaf.version_method ?? "",
-        retrieved_at: leaf.retrieved_at ?? "",
-        urls: leaf.urls ?? [],
-      })
+    const collectLeaves = (node: Release, viaPath: string[]) => {
+      const sub = node.sources ?? []
+      if (sub.length === 0) {
+        if (!node.id) return
+        rows.push({
+          ingest: build.id!,
+          ingest_version: build.version ?? "",
+          transform_version: build.transform_version ?? "",
+          biolink_version: build.biolink_version ?? "",
+          build_version: build.build_version ?? "",
+          generated_at: build.generated_at ?? "",
+          via: viaPath.join("/"),
+          infores: node.id,
+          name: node.name ?? "",
+          version: node.version ?? "",
+          version_method: node.version_method ?? "",
+          retrieved_at: node.retrieved_at ?? "",
+          urls: node.urls ?? [],
+        })
+        return
+      }
+      // Each level deeper than the immediate build becomes part of the via path.
+      const nextVia = node === build ? viaPath : (node.id ? [...viaPath, node.id] : viaPath)
+      for (const child of sub) collectLeaves(child, nextVia)
     }
+    collectLeaves(build, [])
   }
   return rows.sort(
     (a, b) =>
       a.ingest.localeCompare(b.ingest) ||
+      a.via.localeCompare(b.via) ||
       a.infores.localeCompare(b.infores) ||
       a.version.localeCompare(b.version)
   )

--- a/monarch-qc-dashboard/test/sources_utils.test.ts
+++ b/monarch-qc-dashboard/test/sources_utils.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest"
+import {
+  flattenSources,
+  flattenByIngest,
+  compareSources,
+  Release,
+  SourceRow,
+} from "../src/sources_utils"
+
+const sample: Release = {
+  id: "monarch-kg",
+  version: "2026-05-03",
+  sources: [
+    {
+      id: "alliance-ingest",
+      version: "8.3.0",
+      build_version: "alliance-ingest_8.3.0_abc_4.3.9",
+      sources: [
+        {
+          id: "infores:agr",
+          name: "Alliance of Genome Resources",
+          version: "8.3.0",
+          version_method: "alliance_fms_api",
+          urls: ["https://fms.alliancegenome.org/x"],
+        },
+      ],
+    },
+    {
+      id: "hgnc-ingest",
+      version: "2026-05-01",
+      sources: [
+        {
+          id: "infores:agr",
+          name: "Alliance of Genome Resources",
+          version: "8.3.0",
+          version_method: "alliance_fms_api",
+        },
+      ],
+    },
+    {
+      id: "pantherdb-orthologs-ingest",
+      version: "2026-04-01",
+      sources: [
+        {
+          id: "infores:ncbi-gene",
+          name: "NCBI Gene",
+          version: "2026-05-01",
+          version_method: "http_last_modified",
+        },
+      ],
+    },
+    {
+      id: "ncbi-gene",
+      version: "2026-05-02",
+      sources: [
+        {
+          id: "infores:ncbi-gene",
+          name: "NCBI Gene",
+          version: "2026-05-02",
+          version_method: "http_last_modified",
+        },
+      ],
+    },
+  ],
+}
+
+describe("flattenSources", () => {
+  it("emits one row per (infores, version) tuple", () => {
+    const rows = flattenSources(sample)
+    expect(rows.map((r) => `${r.infores}|${r.version}`)).toEqual([
+      "infores:agr|8.3.0",
+      "infores:ncbi-gene|2026-05-01",
+      "infores:ncbi-gene|2026-05-02",
+    ])
+  })
+
+  it("groups ingests at the same (infores, version) under consumed_by", () => {
+    const rows = flattenSources(sample)
+    const agr = rows.find((r) => r.infores === "infores:agr")!
+    expect(agr.consumed_by.sort()).toEqual(["alliance-ingest", "hgnc-ingest"])
+  })
+
+  it("emits separate rows when ingests captured different versions of the same source", () => {
+    const rows = flattenSources(sample)
+    const ncbiRows = rows.filter((r) => r.infores === "infores:ncbi-gene")
+    expect(ncbiRows).toHaveLength(2)
+    const v1 = ncbiRows.find((r) => r.version === "2026-05-01")!
+    const v2 = ncbiRows.find((r) => r.version === "2026-05-02")!
+    expect(v1.consumed_by).toEqual(["pantherdb-orthologs-ingest"])
+    expect(v2.consumed_by).toEqual(["ncbi-gene"])
+  })
+
+  it("returns empty for null/undefined input", () => {
+    expect(flattenSources(null)).toEqual([])
+    expect(flattenSources(undefined)).toEqual([])
+  })
+
+  it("returns empty for legacy-shape receipts (no recursive sources, no id)", () => {
+    const legacy = {
+      "kg-version": "2026-04-01",
+      packages: { biolink: "4.3.9", koza: "2.3.0" },
+      data: { phenio: "v2026-04-14", alliance: "8.3.0" },
+    } as unknown as Release
+    expect(flattenSources(legacy)).toEqual([])
+  })
+})
+
+const row = (overrides: Partial<SourceRow>): SourceRow => ({
+  infores: "infores:x",
+  name: "X",
+  version: "1",
+  version_method: "url_path",
+  retrieved_at: "",
+  urls: [],
+  consumed_by: ["x-ingest"],
+  ...overrides,
+})
+
+describe("compareSources", () => {
+  it("flags new (infores, version) tuples as added", () => {
+    const cur = [row({ infores: "infores:hgnc", version: "2026-05-01" })]
+    const prev = [row({ infores: "infores:hgnc", version: "2026-04-01" })]
+    const rows = compareSources(cur, prev)
+    expect(rows.find((r) => r.version === "2026-05-01")?.status).toBe("added")
+    expect(rows.find((r) => r.version === "2026-04-01")?.status).toBe("removed")
+  })
+
+  it("clusters added+removed rows for the same infores adjacently", () => {
+    const cur = [row({ infores: "infores:hgnc", version: "2026-05-01" })]
+    const prev = [row({ infores: "infores:hgnc", version: "2026-04-01" })]
+    const rows = compareSources(cur, prev)
+    expect(rows.map((r) => r.version)).toEqual(["2026-04-01", "2026-05-01"])
+  })
+
+  it("marks unchanged when the (infores, version) pair is in both", () => {
+    const cur = [row({ infores: "infores:hgnc", version: "2026-05-01" })]
+    const prev = [row({ infores: "infores:hgnc", version: "2026-05-01" })]
+    expect(compareSources(cur, prev)[0].status).toBe("unchanged")
+  })
+
+  it("returns rows as unchanged when no previous is provided", () => {
+    const cur = [row({ infores: "infores:hgnc", version: "2026-05-01" })]
+    expect(compareSources(cur, null).every((r) => r.status === "unchanged")).toBe(true)
+  })
+})
+
+describe("flattenByIngest", () => {
+  it("emits one row per (ingest, leaf) tuple, sorted ingest then infores", () => {
+    const rows = flattenByIngest(sample)
+    expect(rows.map((r) => `${r.ingest}|${r.infores}|${r.version}`)).toEqual([
+      "alliance-ingest|infores:agr|8.3.0",
+      "hgnc-ingest|infores:agr|8.3.0",
+      "ncbi-gene|infores:ncbi-gene|2026-05-02",
+      "pantherdb-orthologs-ingest|infores:ncbi-gene|2026-05-01",
+    ])
+  })
+
+  it("carries the ingest's own build metadata onto each row", () => {
+    const rows = flattenByIngest(sample)
+    const alliance = rows.find((r) => r.ingest === "alliance-ingest")!
+    expect(alliance.ingest_version).toBe("8.3.0")
+    expect(alliance.build_version).toBe("alliance-ingest_8.3.0_abc_4.3.9")
+  })
+
+  it("returns empty for legacy / null receipts", () => {
+    expect(flattenByIngest(null)).toEqual([])
+    expect(flattenByIngest(undefined)).toEqual([])
+    const legacy = { "kg-version": "x", packages: {} } as unknown as Release
+    expect(flattenByIngest(legacy)).toEqual([])
+  })
+})

--- a/monarch-qc-dashboard/test/sources_utils.test.ts
+++ b/monarch-qc-dashboard/test/sources_utils.test.ts
@@ -3,6 +3,7 @@ import {
   flattenSources,
   flattenByIngest,
   compareSources,
+  groupBy,
   Release,
   SourceRow,
 } from "../src/sources_utils"
@@ -167,5 +168,71 @@ describe("flattenByIngest", () => {
     expect(flattenByIngest(undefined)).toEqual([])
     const legacy = { "kg-version": "x", packages: {} } as unknown as Release
     expect(flattenByIngest(legacy)).toEqual([])
+  })
+})
+
+describe("flattenSources collapsing", () => {
+  it("collapses 3+ ingests at the same (infores, version) into one row", () => {
+    const r: Release = {
+      id: "monarch-kg",
+      sources: [
+        { id: "a-ingest", sources: [{ id: "infores:foo", version: "1" }] },
+        { id: "b-ingest", sources: [{ id: "infores:foo", version: "1" }] },
+        { id: "c-ingest", sources: [{ id: "infores:foo", version: "1" }] },
+      ],
+    }
+    const rows = flattenSources(r)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].consumed_by.sort()).toEqual(["a-ingest", "b-ingest", "c-ingest"])
+  })
+})
+
+describe("compareSources contract", () => {
+  it("emits no add/remove markers when previous is null (all unchanged)", () => {
+    const cur = [row({ infores: "infores:hgnc", version: "v1" })]
+    const out = compareSources(cur, null)
+    expect(out.every((r) => r.status === "unchanged")).toBe(true)
+  })
+
+  it("a version bump produces exactly one removed + one added row, clustered by infores", () => {
+    const cur = [
+      row({ infores: "infores:other", version: "1" }),
+      row({ infores: "infores:hgnc", version: "v2" }),
+    ]
+    const prev = [
+      row({ infores: "infores:other", version: "1" }),
+      row({ infores: "infores:hgnc", version: "v1" }),
+    ]
+    const out = compareSources(cur, prev)
+    const hgnc = out.filter((r) => r.infores === "infores:hgnc")
+    expect(hgnc.map((r) => `${r.version}:${r.status}`)).toEqual([
+      "v1:removed",
+      "v2:added",
+    ])
+    // Clustered: the two hgnc rows are adjacent in the output.
+    const idxs = out.map((r) => r.infores)
+    expect(idxs.indexOf("infores:hgnc") + 1).toBe(idxs.lastIndexOf("infores:hgnc"))
+  })
+})
+
+describe("groupBy", () => {
+  it("marks first row of each contiguous group with groupSize", () => {
+    const data = [
+      { k: "a", v: 1 }, { k: "a", v: 2 }, { k: "b", v: 1 }, { k: "c", v: 1 }, { k: "c", v: 2 }, { k: "c", v: 3 },
+    ]
+    const grouped = groupBy(data, (r) => r.k)
+    expect(grouped.map((r) => `${r.k}:${r.groupStart}:${r.groupSize}`)).toEqual([
+      "a:true:2", "a:false:1",
+      "b:true:1",
+      "c:true:3", "c:false:1", "c:false:1",
+    ])
+  })
+
+  it("sorts so non-contiguous keys still group correctly", () => {
+    const data = [{ k: "a" }, { k: "b" }, { k: "a" }]
+    const grouped = groupBy(data, (r) => r.k)
+    expect(grouped.map((r) => `${r.k}:${r.groupStart}:${r.groupSize}`)).toEqual([
+      "a:true:2", "a:false:1", "b:true:1",
+    ])
   })
 })

--- a/monarch-qc-dashboard/test/sources_utils.test.ts
+++ b/monarch-qc-dashboard/test/sources_utils.test.ts
@@ -171,6 +171,66 @@ describe("flattenByIngest", () => {
   })
 })
 
+const threeDeep: Release = {
+  id: "monarch-kg",
+  version: "2026-05-05",
+  sources: [
+    { id: "alliance-ingest", sources: [{ id: "infores:agr", version: "8.3.0" }] },
+    {
+      id: "kg-phenio",
+      version: "v2026-04-14",
+      sources: [
+        {
+          id: "phenio",
+          version: "v2026-04-14",
+          sources: [
+            { id: "infores:hp", version: "2026-04-15" },
+            { id: "infores:chebi", version: "2026-04-20" },
+          ],
+        },
+        { id: "infores:upheno-cross-species", version: "2026-05-03" },
+      ],
+    },
+  ],
+}
+
+describe("flattenSources path tracking", () => {
+  it("emits slash-separated ancestor path in consumed_by for nested leaves", () => {
+    const rows = flattenSources(threeDeep)
+    const hp = rows.find((r) => r.infores === "infores:hp")!
+    expect(hp.consumed_by).toEqual(["kg-phenio/phenio"])
+  })
+
+  it("preserves single-element consumed_by for direct (2-deep) leaves", () => {
+    const rows = flattenSources(threeDeep)
+    const agr = rows.find((r) => r.infores === "infores:agr")!
+    expect(agr.consumed_by).toEqual(["alliance-ingest"])
+  })
+
+  it("treats peer leaves under the same ingest as same depth (no via path)", () => {
+    const rows = flattenSources(threeDeep)
+    const upheno = rows.find((r) => r.infores === "infores:upheno-cross-species")!
+    expect(upheno.consumed_by).toEqual(["kg-phenio"])
+  })
+})
+
+describe("flattenByIngest 3-deep", () => {
+  it("descends past intermediate builds; via captures the intermediate id", () => {
+    const rows = flattenByIngest(threeDeep)
+    const hp = rows.find((r) => r.infores === "infores:hp")!
+    expect(hp.ingest).toBe("kg-phenio")
+    expect(hp.via).toBe("phenio")
+  })
+
+  it("via is empty for direct-leaf cases", () => {
+    const rows = flattenByIngest(threeDeep)
+    const agr = rows.find((r) => r.infores === "infores:agr")!
+    expect(agr.via).toBe("")
+    const upheno = rows.find((r) => r.infores === "infores:upheno-cross-species")!
+    expect(upheno.via).toBe("")
+  })
+})
+
 describe("flattenSources collapsing", () => {
   it("collapses 3+ ingests at the same (infores, version) into one row", () => {
     const r: Release = {


### PR DESCRIPTION
## Summary
New top-level "Source Versions" tab that renders monarch-kg's build receipt (`metadata.yaml`, kozahub-metadata-schema). Two views:

- **By source** — one row per `(infores, version)` tuple, grouped visually (rowspan) by `infores`. Shared versions across ingests collapse to one row with a `consumed_by` list; disagreements become two rows clustered under the same Source/Name cell.
- **By ingest** — one row per `(ingest, infores, version)`, grouped by ingest with the ingest's own `version` / `transform_version` / `biolink_version` pinned to the left.

The existing "Compare to:" selector adds an added / removed marker per `(infores, version)` tuple, so a version bump appears as a removed + added row clustered under the same infores group.

The receipt's `disagreements` and `version_drift` (defined in [monarch-ingest #682](https://github.com/monarch-initiative/monarch-ingest/pull/682)) are surfaced as collapsible alert sections above the table. Legacy-shape receipts on older releases (pre-recursive-Release format) render as empty rather than crashing.

## Test plan
- [x] 12 unit tests pass (\`flattenSources\`, \`flattenByIngest\`, \`compareSources\`, including coverage for legacy receipts and disagreement bucketing).
- [x] \`yarn vue-tsc --noEmit\` clean; \`yarn build\` clean.
- [x] Live: ran \`flattenSources\` against \`https://data.monarchinitiative.org/monarch-kg-dev/latest/metadata.yaml\` — 23 ingest builds → 31 (infores, version) rows including the genuine \`infores:ncbi-gene\` disagreement (one row at \`2026-05-01\` consumed by pantherdb-orthologs-ingest, one at \`2026-05-02\` consumed by ncbi-gene).
- [x] Manual: dev server renders both views, tab toggle works, rowspan grouping shows ncbi-gene's two version rows clustered under one Source cell.