### PR TITLE
Auto-deploy to GitHub Pages via Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: monarch-qc-dashboard
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: monarch-qc-dashboard/yarn.lock
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn build
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: monarch-qc-dashboard/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/monarch-qc-dashboard/public/CNAME
+++ b/monarch-qc-dashboard/public/CNAME
@@ -1,0 +1,1 @@
+qc.monarchinitiative.org


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` — builds `monarch-qc-dashboard` and publishes `dist/` to GitHub Pages on every push to `main` (also runnable via `workflow_dispatch`). Uses the official `actions/upload-pages-artifact` + `actions/deploy-pages` flow.
- Adds `monarch-qc-dashboard/public/CNAME` containing `qc.monarchinitiative.org` so Vite copies it into `dist/` and the custom domain stays bound under the Actions-based deploy.

## Prereq (already done)
- Repo Settings → Pages → Source switched from "Deploy from a branch" to "GitHub Actions".

## Test plan
- [ ] Merge to `main`; confirm the `deploy` workflow runs and both `build` and `deploy` jobs succeed.
- [ ] After deploy, confirm `https://qc.monarchinitiative.org/` serves the latest build (Source Versions page reachable via the nav).
- [ ] Confirm the deployment shows up under Settings → Pages with the `github-pages` environment.